### PR TITLE
feat: support OAuth/subscription auth for Claude Code backend

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -41,7 +41,8 @@ export const initCommand = new Command('init')
     }
 
     // On --force, preserve existing authMode if --auth-mode wasn't explicitly passed
-    if (options.force && options.authMode === 'api-key' && existingConfig.authMode) {
+    const authModeExplicit = process.argv.includes('--auth-mode');
+    if (options.force && !authModeExplicit && existingConfig.authMode) {
       authMode = existingConfig.authMode;
     }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { getEvolveDir, getTemplatesDir, projectFile, evolveFile, isInitialized, EVOLVE_DIR_NAME } from '../utils/paths';
 import { checkDependencies, formatDependencyResults } from '../utils/checks';
-import { readConfig, writeConfig, isValidAgent, getAgentEnvHint } from '../utils/config';
+import { readConfig, writeConfig, isValidAgent, getAgentEnvHint, AuthMode } from '../utils/config';
 
 // Files that contain user/agent evolution history — never overwrite
 const PRESERVE_STATE_FILES = ['JOURNAL.md', 'LEARNINGS.md', 'DAY_COUNT', '.birth_date'];
@@ -13,7 +13,8 @@ export const initCommand = new Command('init')
   .option('--with-ci', 'Install GitHub Actions workflows')
   .option('--force', 'Overwrite existing .evolve/ directory')
   .option('--agent <name>', 'Agent backend to use (claude, codex, opencode, ollama)', 'claude')
-  .action(async (options: { withCi?: boolean; force?: boolean; agent: string }) => {
+  .option('--auth-mode <mode>', 'Auth mode for Claude: api-key or oauth', 'api-key')
+  .action(async (options: { withCi?: boolean; force?: boolean; agent: string; authMode: string }) => {
     const evolveDir = getEvolveDir();
     const templatesDir = getTemplatesDir();
 
@@ -24,6 +25,24 @@ export const initCommand = new Command('init')
     if (!isValidAgent(agent)) {
       console.error(`Unknown agent "${agent}". Supported: claude, codex, opencode, ollama`);
       process.exit(1);
+    }
+
+    // Resolve auth mode
+    let authMode: AuthMode = 'api-key';
+    if (options.authMode === 'oauth') {
+      if (agent !== 'claude') {
+        console.warn(`Warning: --auth-mode oauth is only applicable to the Claude agent. Falling back to api-key.`);
+      } else {
+        authMode = 'oauth';
+      }
+    } else if (options.authMode !== 'api-key') {
+      console.error(`Unknown auth mode "${options.authMode}". Supported: api-key, oauth`);
+      process.exit(1);
+    }
+
+    // On --force, preserve existing authMode if --auth-mode wasn't explicitly passed
+    if (options.force && options.authMode === 'api-key' && existingConfig.authMode) {
+      authMode = existingConfig.authMode;
     }
 
     // Check dependencies
@@ -123,9 +142,12 @@ export const initCommand = new Command('init')
 
     // Write agent config
     const currentConfig = readConfig();
-    writeConfig({ ...currentConfig, agent });
+    writeConfig({ ...currentConfig, agent, authMode });
     if (agent !== 'claude') {
       console.log(`  Agent: ${agent}`);
+    }
+    if (authMode === 'oauth') {
+      console.log(`  Auth: OAuth (claude login)`);
     }
 
     console.log('');
@@ -134,7 +156,7 @@ export const initCommand = new Command('init')
     console.log('Next steps:');
     console.log('  1. Edit .evolve/vision.md with your project vision');
     console.log('  2. Edit .evolve/spec.md with your technical specification');
-    console.log(`  3. ${getAgentEnvHint(agent)}`);
+    console.log(`  3. ${getAgentEnvHint(agent, authMode)}`);
     console.log('  4. Run: code-evolve run');
     if (!options.withCi) {
       console.log('');

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -25,11 +25,12 @@ export const runCommand = new Command('run')
     }
 
     const model = options.model || getDefaultModel(agent);
-    const envKey = getAgentEnvKey(agent);
+    const authMode = config.authMode;
+    const envKey = getAgentEnvKey(agent, authMode);
 
     if (envKey && !process.env[envKey]) {
       console.error(`${envKey} is not set.`);
-      console.error(getAgentEnvHint(agent));
+      console.error(getAgentEnvHint(agent, authMode));
       process.exit(3);
     }
 
@@ -44,6 +45,7 @@ export const runCommand = new Command('run')
       TIMEOUT: options.timeout,
       AGENT: agent,
       ...(options.force ? { FORCE_RUN: 'true' } : {}),
+      ...(authMode === 'oauth' ? { CLAUDE_AUTH_MODE: 'oauth' } : {}),
     };
 
     const child = spawn('bash', [scriptPath], {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -41,18 +41,19 @@ export const startCommand = new Command('start')
       process.exit(1);
     }
 
-    const envKey = getAgentEnvKey(agent);
+    const authMode = config.authMode;
+    const envKey = getAgentEnvKey(agent, authMode);
 
     if (envKey && !process.env[envKey]) {
       console.error(`${envKey} is not set in your environment.`);
-      console.error(getAgentEnvHint(agent));
+      console.error(getAgentEnvHint(agent, authMode));
       process.exit(3);
     }
 
     const model = options.model || getDefaultModel(agent);
 
     // Persist agent choice
-    writeConfig({ ...config, agent });
+    writeConfig({ ...config, agent, authMode });
 
     const projectDir = process.cwd();
     const evolveDir = getEvolveDir();
@@ -61,8 +62,8 @@ export const startCommand = new Command('start')
     const scriptPath = path.join(evolveDir, 'scripts', 'evolve.sh');
 
     // Write .env file for cron (cron doesn't inherit shell env)
-    writeEnvFile(envFile, model, agent);
-    console.log('Saved API key to .evolve/.env');
+    writeEnvFile(envFile, model, agent, authMode);
+    console.log('Saved environment config to .evolve/.env');
 
     // Ensure .evolve/.env is gitignored
     ensureEnvGitignored(projectDir);
@@ -98,7 +99,7 @@ export const startCommand = new Command('start')
     console.log(`Logs: .evolve/evolve.log`);
 
     // Save schedule config for status command
-    const scheduleConfig = { every: hours, model, agent, started: new Date().toISOString() };
+    const scheduleConfig = { every: hours, model, agent, authMode: authMode || 'api-key', started: new Date().toISOString() };
     fs.writeFileSync(path.join(evolveDir, 'schedule.json'), JSON.stringify(scheduleConfig, null, 2) + '\n');
 
     if (options.runNow) {
@@ -115,6 +116,7 @@ export const startCommand = new Command('start')
           PROJECT_DIR: '.',
           MODEL: model,
           AGENT: agent,
+          ...(authMode === 'oauth' ? { CLAUDE_AUTH_MODE: 'oauth' } : {}),
         },
       });
       child.on('close', (code: number | null) => {
@@ -127,19 +129,22 @@ export const startCommand = new Command('start')
     }
   });
 
-function writeEnvFile(envFile: string, model: string, agent: string): void {
+function writeEnvFile(envFile: string, model: string, agent: string, authMode?: string): void {
   const lines: string[] = [];
 
-  // Include the relevant API key
-  if (process.env.ANTHROPIC_API_KEY) {
-    lines.push(`ANTHROPIC_API_KEY="${process.env.ANTHROPIC_API_KEY}"`);
-  }
-  if (process.env.OPENAI_API_KEY) {
-    lines.push(`OPENAI_API_KEY="${process.env.OPENAI_API_KEY}"`);
+  // Include the relevant API key (skip for OAuth mode)
+  if (authMode !== 'oauth') {
+    if (process.env.ANTHROPIC_API_KEY) {
+      lines.push(`ANTHROPIC_API_KEY="${process.env.ANTHROPIC_API_KEY}"`);
+    }
+    if (process.env.OPENAI_API_KEY) {
+      lines.push(`OPENAI_API_KEY="${process.env.OPENAI_API_KEY}"`);
+    }
   }
 
   lines.push(`MODEL="${model}"`);
   lines.push(`AGENT="${agent}"`);
+  lines.push(`CLAUDE_AUTH_MODE="${authMode || 'api-key'}"`);
 
   // Preserve PATH so cron can find claude, git, python3
   if (process.env.PATH) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,9 +1,12 @@
 import fs from 'fs';
 import { evolveFile } from './paths';
 
+export type AuthMode = 'api-key' | 'oauth';
+
 export interface EvolveConfig {
   agent: string;
   model?: string;
+  authMode?: AuthMode;
 }
 
 const CONFIG_FILE = 'config.json';
@@ -47,7 +50,8 @@ const AGENT_ENV_KEYS: Record<string, string> = {
   ollama: '',
 };
 
-export function getAgentEnvKey(agent: string): string {
+export function getAgentEnvKey(agent: string, authMode?: AuthMode): string {
+  if (agent === 'claude' && authMode === 'oauth') return '';
   return AGENT_ENV_KEYS[agent] || '';
 }
 
@@ -62,7 +66,10 @@ export function getDefaultModel(agent: string): string {
   return AGENT_DEFAULT_MODELS[agent] || 'claude-sonnet-4-6';
 }
 
-export function getAgentEnvHint(agent: string): string {
+export function getAgentEnvHint(agent: string, authMode?: AuthMode): string {
+  if (agent === 'claude' && authMode === 'oauth') {
+    return 'Ensure you are logged in via `claude login` (OAuth/subscription auth)';
+  }
   switch (agent) {
     case 'claude':
       return 'Set ANTHROPIC_API_KEY environment variable';

--- a/templates/scripts/agents/claude.sh
+++ b/templates/scripts/agents/claude.sh
@@ -7,9 +7,8 @@ check_agent() {
 
 agent_auth_check() {
     if [ "$CLAUDE_AUTH_MODE" = "oauth" ]; then
-        if ! claude --version &>/dev/null; then
-            echo "ERROR: Claude CLI not responding. Is your OAuth session active?" >&2
-            echo "Run 'claude login' to re-authenticate." >&2
+        if ! claude auth status &>/dev/null; then
+            echo "ERROR: Claude not authenticated. Run 'claude auth login' to authenticate." >&2
             return 1
         fi
     fi

--- a/templates/scripts/agents/claude.sh
+++ b/templates/scripts/agents/claude.sh
@@ -5,6 +5,16 @@ check_agent() {
     command -v claude &>/dev/null
 }
 
+agent_auth_check() {
+    if [ "$CLAUDE_AUTH_MODE" = "oauth" ]; then
+        if ! claude --version &>/dev/null; then
+            echo "ERROR: Claude CLI not responding. Is your OAuth session active?" >&2
+            echo "Run 'claude login' to re-authenticate." >&2
+            return 1
+        fi
+    fi
+}
+
 # run_agent <prompt_file> <model> <timeout_cmd> <timeout>
 run_agent() {
     local prompt_file="$1"
@@ -12,11 +22,17 @@ run_agent() {
     local timeout_cmd="$3"
     local timeout="$4"
 
+    agent_auth_check || return 1
+
     ${timeout_cmd:+$timeout_cmd "$timeout"} claude -p --model "$model" \
         --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
         < "$prompt_file" 2>&1
 }
 
 agent_env_hint() {
-    echo "ANTHROPIC_API_KEY"
+    if [ "$CLAUDE_AUTH_MODE" = "oauth" ]; then
+        echo "Run 'claude login' to authenticate via OAuth"
+    else
+        echo "ANTHROPIC_API_KEY"
+    fi
 }

--- a/templates/workflows/evolve.yml
+++ b/templates/workflows/evolve.yml
@@ -47,7 +47,10 @@ jobs:
         id: attempt1
         continue-on-error: true
         env:
+          # OAuth auth is local-only. CI always requires ANTHROPIC_API_KEY.
+          # If your local setup uses OAuth, you must still set this secret for CI.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_AUTH_MODE: api-key
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
@@ -61,7 +64,9 @@ jobs:
         if: steps.attempt1.outcome == 'failure'
         continue-on-error: true
         env:
+          # OAuth auth is local-only. CI always requires ANTHROPIC_API_KEY.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_AUTH_MODE: api-key
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
@@ -74,7 +79,9 @@ jobs:
       - name: Retry after 45min
         if: steps.attempt1.outcome == 'failure' && steps.attempt2.outcome == 'failure'
         env:
+          # OAuth auth is local-only. CI always requires ANTHROPIC_API_KEY.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_AUTH_MODE: api-key
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}


### PR DESCRIPTION
## Summary

- Adds `--auth-mode <api-key|oauth>` flag to `code-evolve init` so users with a Claude subscription can skip providing `ANTHROPIC_API_KEY`
- OAuth mode skips API key validation in `run` and `start`, relying on `claude login` session instead
- `claude.sh` adapter validates OAuth session is active before running cycles
- CI workflows always use `api-key` mode with a clear comment explaining the split

Closes #15

## Files Changed

| File | Change |
|------|--------|
| `src/utils/config.ts` | Added `AuthMode` type, `authMode` to `EvolveConfig`, auth-aware `getAgentEnvKey`/`getAgentEnvHint` |
| `src/commands/init.ts` | `--auth-mode` flag, validation, persistence |
| `src/commands/start.ts` | Reads `authMode` from config, passes `CLAUDE_AUTH_MODE` to env and `.env` file |
| `src/commands/run.ts` | Reads `authMode` from config, passes `CLAUDE_AUTH_MODE` to spawn env |
| `templates/scripts/agents/claude.sh` | `agent_auth_check()` for OAuth validation, conditional `agent_env_hint()` |
| `templates/workflows/evolve.yml` | Explicit `CLAUDE_AUTH_MODE: api-key` + documentation comments |

## Test plan

- [ ] `code-evolve init --agent claude --auth-mode oauth` → config.json has `authMode: "oauth"`, next steps show OAuth hint
- [ ] `code-evolve init --agent claude` → defaults to `api-key` mode (backwards compatible)
- [ ] `code-evolve init --agent codex --auth-mode oauth` → warns and falls back to `api-key`
- [ ] `code-evolve init --auth-mode invalid` → error exit
- [ ] `code-evolve run` with OAuth config → no `ANTHROPIC_API_KEY` check, passes `CLAUDE_AUTH_MODE=oauth` to shell
- [ ] `code-evolve start` with OAuth config → `.env` file has `CLAUDE_AUTH_MODE="oauth"` and no API key lines
- [ ] `code-evolve init --force` preserves existing `authMode` when `--auth-mode` not explicitly passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth authentication mode for Claude alongside API-key, selectable via a new --auth-mode setup option.
  * Selected auth mode is saved and applied across commands, preserved when forcing reinit unless changed.
  * Runtime and generated env files now include CLAUDE_AUTH_MODE so runs and cron jobs use the chosen mode.
  * Scripts and guidance now show OAuth-specific hints and prompt login when OAuth is selected; CI workflows default to api-key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->