### PR TITLE
feat(init): interactive agent + auth picker on TTY (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ All commands are available as both `code-evolve <cmd>` and `ce <cmd>`.
 ### `init`
 
 ```bash
-code-evolve init                          # basic setup (uses Claude Code by default)
-code-evolve init --agent codex            # use Codex CLI instead
+code-evolve init                          # on a terminal, prompts for agent + auth (Claude/api-key by default)
+code-evolve init --agent codex            # skip the prompt; use Codex CLI
 code-evolve init --auth-mode oauth        # use Claude subscription (claude login) instead of API key
 code-evolve init --with-ci               # also install GitHub Actions for cloud evolution
 code-evolve init --force                 # upgrade framework files (preserves journal + learnings)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -13,7 +13,7 @@ But the product the user is describing — *"open any repo, install, get intervi
 
 - ~~**The GitHub Action path is currently dead** — workflows install into a subdirectory GitHub never executes (P0.1).~~ **RESOLVED** in #36 — workflows now install directly into `.github/workflows/` with collision-safe names. (Per-agent CI for non-Claude backends remains a follow-up.)
 - **True greenfield (zero-commit) repos abort immediately** on session start (P0.2).
-- **There is no guided onboarding.** Everything is non-interactive flags a user must discover. No LLM picker, no spec generator, the existing vision interview is hardcoded (not LLM-driven) and not even wired into `init`, and there is no "choose local / CI / both + pick a schedule" step (P1.x).
+- **Guided onboarding is still thin.** `init` now prompts for the agent + auth backend on a TTY (P1.1, #20), but there is still no spec generator, the existing vision interview is hardcoded (not LLM-driven) and not wired into `init`, and there is no "choose local / CI / both + pick a schedule" step (P1.x).
 
 Beyond that, breadth (more languages), non-Claude backend robustness, and package hygiene (no tests, doc drift) are the long tail.
 
@@ -40,7 +40,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 - **Greenfield abort.** `evolve.sh:277` runs `git rev-parse HEAD` under `set -euo pipefail` (`:23`). On a freshly `git init`'d repo with no commits this exits non-zero and kills the session before any work. → **P0.2**
 
 ### 2. Guided installation (the "turn on" experience — the heart of the ask)
-- No interactive **LLM/agent picker**; `init` silently defaults to `claude`/`api-key`. → **P1.1**
+- ~~No interactive **LLM/agent picker**; `init` silently defaults to `claude`/`api-key`.~~ **DONE** (#20) — `init` prompts for agent + auth on a TTY; flags/non-TTY skip it. → **P1.1**
 - No **spec generator** — `spec.md` is always hand-written. → **P1.2**
 - `init` never offers to generate artifacts; the `vision` interview is disconnected and undocumented. → **P1.3**
 - The interview is **hardcoded string Q&A, not the LLM interviewing the user**. → **P1.4**
@@ -69,7 +69,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 |-------|---|----------|-------|------------|
 | P0.1 | [#18](https://github.com/frankbria/code-evolve/issues/18) ✅ | Blocker | Install GitHub Actions workflows into `.github/workflows/` so they actually run *(done in #36)* | — |
 | P0.2 | [#19](https://github.com/frankbria/code-evolve/issues/19) | Blocker | Handle zero-commit / greenfield repos without aborting the session | — |
-| P1.1 | [#20](https://github.com/frankbria/code-evolve/issues/20) | High | Interactive LLM/agent + auth picker on `init` | — |
+| P1.1 | [#20](https://github.com/frankbria/code-evolve/issues/20) ✅ | High | Interactive LLM/agent + auth picker on `init` *(done in #39)* | — |
 | P1.2 | [#21](https://github.com/frankbria/code-evolve/issues/21) | High | Add `spec` interview command to generate `spec.md` | — |
 | P1.3 | [#22](https://github.com/frankbria/code-evolve/issues/22) | High | Wire `init` to offer vision + spec generation after install | P1.1, P1.2 |
 | P1.4 | [#23](https://github.com/frankbria/code-evolve/issues/23) | High | Make the vision/spec interview LLM-driven via the chosen agent | P1.1 |

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,9 +1,18 @@
 import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
+import readline from 'readline';
 import { getEvolveDir, getTemplatesDir, projectFile, evolveFile, isInitialized, EVOLVE_DIR_NAME } from '../utils/paths';
 import { checkDependencies, formatDependencyResults } from '../utils/checks';
-import { readConfig, writeConfig, isValidAgent, getAgentEnvHint, AuthMode } from '../utils/config';
+import {
+  readConfig,
+  writeConfig,
+  isValidAgent,
+  getAgentEnvHint,
+  getSupportedAgents,
+  resolveAgentSelection,
+  AuthMode,
+} from '../utils/config';
 
 // Files that contain user/agent evolution history — never overwrite
 const PRESERVE_STATE_FILES = ['JOURNAL.md', 'LEARNINGS.md', 'DAY_COUNT', '.birth_date'];
@@ -18,32 +27,48 @@ export const initCommand = new Command('init')
     const evolveDir = getEvolveDir();
     const templatesDir = getTemplatesDir();
 
-    // Resolve agent: use existing config on --force if --agent not explicitly passed
+    // Detect whether flags were explicitly passed (handles both `--agent x` and `--agent=x`)
+    const flagPassed = (flag: string): boolean =>
+      process.argv.some((a) => a === flag || a.startsWith(`${flag}=`));
+    const agentExplicit = flagPassed('--agent');
+    const authModeExplicit = flagPassed('--auth-mode');
+    const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+    // Resolve agent: explicit flag wins; else existing config on --force; else default.
     const existingConfig = options.force ? readConfig() : { agent: 'claude' };
-    const agent = options.agent !== 'claude' ? options.agent : existingConfig.agent || 'claude';
+    let agent = agentExplicit ? options.agent : existingConfig.agent || 'claude';
 
-    if (!isValidAgent(agent)) {
-      console.error(`Unknown agent "${agent}". Supported: claude, codex, opencode, ollama`);
-      process.exit(1);
-    }
-
-    // Resolve auth mode
-    let authMode: AuthMode = 'api-key';
+    // Validate the --auth-mode flag value up front (before any agent-specific rules).
+    let authMode: AuthMode;
     if (options.authMode === 'oauth') {
-      if (agent !== 'claude') {
-        console.warn(`Warning: --auth-mode oauth is only applicable to the Claude agent. Falling back to api-key.`);
-      } else {
-        authMode = 'oauth';
-      }
-    } else if (options.authMode !== 'api-key') {
+      authMode = 'oauth';
+    } else if (options.authMode === 'api-key') {
+      authMode = 'api-key';
+    } else {
       console.error(`Unknown auth mode "${options.authMode}". Supported: api-key, oauth`);
       process.exit(1);
     }
-
-    // On --force, preserve existing authMode if --auth-mode wasn't explicitly passed
-    const authModeExplicit = process.argv.includes('--auth-mode');
+    // On --force, preserve existing authMode if --auth-mode wasn't explicitly passed.
     if (options.force && !authModeExplicit && existingConfig.authMode) {
       authMode = existingConfig.authMode;
+    }
+
+    // Interactive picker: on a TTY, when --agent wasn't passed, ask the user.
+    if (interactive && !agentExplicit) {
+      const picked = await promptForAgentAndAuth(agent, !authModeExplicit);
+      agent = picked.agent;
+      if (picked.authMode) authMode = picked.authMode;
+    }
+
+    if (!isValidAgent(agent)) {
+      console.error(`Unknown agent "${agent}". Supported: ${getSupportedAgents().join(', ')}`);
+      process.exit(1);
+    }
+
+    // oauth only applies to Claude — fall back for other backends.
+    if (authMode === 'oauth' && agent !== 'claude') {
+      console.warn(`Warning: oauth auth is only applicable to the Claude agent. Falling back to api-key.`);
+      authMode = 'api-key';
     }
 
     // Check dependencies
@@ -205,6 +230,40 @@ function copyDir(src: string, dest: string): void {
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
+  }
+}
+
+/**
+ * Interactively prompt for the agent backend (and, for Claude, the auth mode)
+ * using Node's built-in readline. Returns `authMode` only when it was asked.
+ */
+async function promptForAgentAndAuth(
+  defaultAgent: string,
+  askAuth: boolean,
+): Promise<{ agent: string; authMode?: AuthMode }> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (q: string): Promise<string> => new Promise((resolve) => rl.question(q, resolve));
+  try {
+    const agents = getSupportedAgents();
+    console.log('Which agent backend should drive evolution?');
+    agents.forEach((a, i) => console.log(`  ${i + 1}. ${a}${a === defaultAgent ? ' (default)' : ''}`));
+    const defaultIdx = Math.max(agents.indexOf(defaultAgent), 0) + 1;
+    const raw = await ask(`Select [1-${agents.length}] (default ${defaultIdx}): `);
+    const agent = resolveAgentSelection(raw, defaultAgent);
+    if (raw.trim() && agent === defaultAgent && raw.trim() !== defaultAgent && raw.trim() !== String(defaultIdx)) {
+      console.log(`  Unrecognized choice — using ${defaultAgent}.`);
+    }
+
+    if (agent === 'claude' && askAuth) {
+      console.log('Claude auth mode:');
+      console.log('  1. api-key — ANTHROPIC_API_KEY (default)');
+      console.log('  2. oauth — claude login / subscription');
+      const a = (await ask('Select [1-2] (default 1): ')).trim().toLowerCase();
+      return { agent, authMode: a === '2' || a === 'oauth' ? 'oauth' : 'api-key' };
+    }
+    return { agent };
+  } finally {
+    rl.close();
   }
 }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -49,8 +49,21 @@ export const initCommand = new Command('init')
       process.exit(1);
     }
     // On --force, preserve existing authMode if --auth-mode wasn't explicitly passed.
-    if (options.force && !authModeExplicit && existingConfig.authMode) {
-      authMode = existingConfig.authMode;
+    // readConfig() only guarantees `agent` is a string, so validate the on-disk value
+    // before trusting it — a hand-edited config.json must not bypass the check above.
+    const existingAuthMode = (existingConfig as { authMode?: unknown }).authMode;
+    if (options.force && !authModeExplicit && typeof existingAuthMode === 'string') {
+      if (existingAuthMode === 'api-key' || existingAuthMode === 'oauth') {
+        authMode = existingAuthMode;
+      } else {
+        console.warn(`Warning: ignoring unsupported auth mode "${existingAuthMode}" from config.json.`);
+      }
+    }
+
+    // Fail fast before prompting: don't ask agent/auth questions only to abort.
+    if (isInitialized() && !options.force) {
+      console.error(`.evolve/ already exists. Use --force to overwrite.`);
+      process.exit(1);
     }
 
     // Interactive picker: on a TTY, when --agent wasn't passed, ask the user.
@@ -83,12 +96,6 @@ export const initCommand = new Command('init')
       process.exit(3);
     }
     console.log('');
-
-    // Check if already initialized
-    if (isInitialized() && !options.force) {
-      console.error(`.evolve/ already exists. Use --force to overwrite.`);
-      process.exit(1);
-    }
 
     // Create .evolve/ directory structure
     console.log('Creating .evolve/ directory...');

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -43,6 +43,20 @@ export function getSupportedAgents(): string[] {
   return [...SUPPORTED_AGENTS];
 }
 
+/**
+ * Resolve an interactive agent picker answer to an agent name.
+ * Accepts a 1-based list index ("2") or an agent name ("codex").
+ * Empty or unrecognized input falls back to `defaultAgent`.
+ */
+export function resolveAgentSelection(raw: string, defaultAgent: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return defaultAgent;
+  const n = Number(trimmed);
+  if (Number.isInteger(n) && n >= 1 && n <= SUPPORTED_AGENTS.length) return SUPPORTED_AGENTS[n - 1];
+  if (SUPPORTED_AGENTS.includes(trimmed)) return trimmed;
+  return defaultAgent;
+}
+
 const AGENT_ENV_KEYS: Record<string, string> = {
   claude: 'ANTHROPIC_API_KEY',
   codex: 'OPENAI_API_KEY',


### PR DESCRIPTION
Closes #20.

## What

`code-evolve init` now presents an interactive picker when run on a terminal without `--agent`:
- Choose the agent backend (claude / codex / opencode / ollama).
- For Claude, choose the auth mode (api-key / oauth).

Built on Node's built-in `readline` (same dependency-free approach as `vision.ts`). Flags and non-TTY input still skip the prompt, so CI and scripted use are unchanged.

## Changes
- `src/utils/config.ts`: pure `resolveAgentSelection(raw, defaultAgent)` helper (accepts a 1-based index or an agent name; falls back to the default).
- `src/commands/init.ts`: robust explicit-flag detection (`--flag` and `--flag=value`), TTY detection, interactive prompt, and reordered auth validation (validate `--auth-mode` up front; apply the oauth-only-for-Claude rule after the agent is resolved).

## Demo evidence (all run against the built CLI)
| Scenario | Result |
|---|---|
| Bare `init`, piped/non-TTY | prompt skipped → `{agent: claude, authMode: api-key}` |
| `init --agent codex --force` | flag wins, no prompt → `{agent: codex, authMode: api-key}` |
| TTY, pick `1`+`2` | `{agent: claude, authMode: oauth}` |
| TTY, pick `2` | `{agent: codex, authMode: api-key}` (Claude auth prompt correctly skipped) |
| TTY, Enter+Enter | defaults → `{agent: claude, authMode: api-key}` |
| TTY, `--agent claude --auth-mode oauth` | flags win, no prompt → `{agent: claude, authMode: oauth}` |

`resolveAgentSelection` covered by an assert-based check (index, name, empty, out-of-range, garbage).

## Known limitations
- No automated test suite runs in CI yet — the repo has no test framework (tracked separately as #33). Logic is covered by the runnable assert check above and the manual demos.
- On a real TTY, hitting Ctrl-D (EOF) mid-prompt exits cleanly without writing config (no error message); acceptable for an interactive cancel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive setup now prompts for an agent choice when needed, with a clear list of supported options and a sensible default.
  * Claude users can now be prompted to choose an authentication mode during setup.

* **Bug Fixes**
  * Improved handling of command-line flags so `--agent` and `--auth-mode` are recognized reliably in more formats.
  * Existing authentication settings are preserved more consistently when rerunning setup with force options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->