### PR TITLE
feat(spec): add `code-evolve spec` guided interview command (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ You have three options — pick the one that fits:
 
 ```bash
 code-evolve vision
+code-evolve spec
 ```
 
-Five rounds of Socratic questions draw out your project vision — what you're building, who it's for, what problem it solves, and what success looks like. Your answers are assembled into `.evolve/vision.md` with your approval.
-
-Then write `.evolve/spec.md` by hand — define your tech stack, architecture, and a prioritized feature checklist.
+`vision` runs five rounds of Socratic questions — what you're building, who it's for, what problem it solves, and what success looks like — assembled into `.evolve/vision.md` with your approval. `spec` then interviews you on tech stack, architecture, and a prioritized feature checklist, written to `.evolve/spec.md`. Re-run either with `--refine` to revisit prior answers.
 
 **Option B: Write both files directly**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { statusCommand } from './commands/status';
 import { ejectCommand } from './commands/eject';
 import { migrateCommand } from './commands/migrate';
 import { visionCommand } from './commands/vision';
+import { specCommand } from './commands/spec';
 import { proofCommand } from './commands/proof';
 
 const rawName = path.basename(process.argv[1]);
@@ -28,6 +29,7 @@ program.addCommand(statusCommand);
 program.addCommand(ejectCommand);
 program.addCommand(migrateCommand);
 program.addCommand(visionCommand);
+program.addCommand(specCommand);
 program.addCommand(proofCommand);
 
 program.parse();

--- a/src/commands/spec.ts
+++ b/src/commands/spec.ts
@@ -1,0 +1,336 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import readline from 'readline';
+import { evolveFile, getEvolveDir, isInitialized } from '../utils/paths';
+
+type FeatureStatus = ' ' | '~' | 'x';
+
+interface Feature {
+  status: FeatureStatus;
+  text: string;
+}
+
+interface SpecAnswers {
+  techStack: string;
+  architecture: string;
+  features: Feature[];
+  dataModel: string;
+  apiDesign: string;
+  testing: string;
+  deployment: string;
+}
+
+export const specCommand = new Command('spec')
+  .description('Launch a guided interview to generate .evolve/spec.md')
+  .option('--refine', 'Revisit and improve an existing spec.md')
+  .action(async (options: { refine?: boolean }) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    // Line-queue reader: decouples our await pace from readline's emit pace so
+    // piped (non-TTY) input isn't lost between questions, and EOF resolves
+    // pending prompts to '' instead of leaving the process hung.
+    const queue: string[] = [];
+    const waiters: Array<(line: string) => void> = [];
+    let closed = false;
+    rl.on('line', (line) => {
+      const waiter = waiters.shift();
+      if (waiter) waiter(line);
+      else queue.push(line);
+    });
+    rl.on('close', () => {
+      closed = true;
+      while (waiters.length) waiters.shift()!('');
+    });
+    const ask = (question: string): Promise<string> => {
+      process.stdout.write(question);
+      if (queue.length) return Promise.resolve(queue.shift()!);
+      if (closed) return Promise.resolve('');
+      return new Promise((resolve) => waiters.push(resolve));
+    };
+
+    try {
+      console.log('');
+      console.log('=== code-evolve: Spec Interview ===');
+      console.log('');
+      console.log("I'll ask about your tech stack, architecture, and features.");
+      console.log('Answer naturally — short or long is fine. Say "skip" to move on.');
+      console.log('');
+
+      // Refine mode: load existing spec
+      let previousAnswers: SpecAnswers | undefined;
+      if (options.refine) {
+        const specPath = evolveFile('spec.md');
+        if (fs.existsSync(specPath)) {
+          const existingSpec = fs.readFileSync(specPath, 'utf8');
+          previousAnswers = parseSpecDoc(existingSpec);
+          console.log('Found existing .evolve/spec.md. Previous answers will be shown — press Enter to keep them.');
+          console.log('');
+        } else {
+          console.log('No existing .evolve/spec.md found. Starting fresh.');
+          console.log('');
+        }
+      }
+
+      const answers = await runInterview(ask, previousAnswers);
+
+      // Summary
+      console.log('');
+      console.log('=== Summary ===');
+      console.log('');
+      printSummary(answers);
+
+      const confirm = await ask('\nDoes this capture your spec? (yes / edit / cancel) ');
+      const choice = confirm.toLowerCase().trim();
+
+      if (choice === 'cancel' || choice === 'c') {
+        console.log('Cancelled. Nothing was written.');
+        return;
+      }
+
+      let finalAnswers = answers;
+      if (choice === 'edit' || choice === 'e') {
+        console.log('\nLet\'s go through the questions again. Press Enter to keep your previous answer.\n');
+        finalAnswers = await runInterview(ask, answers);
+        console.log('');
+        console.log('=== Updated Summary ===');
+        console.log('');
+        printSummary(finalAnswers);
+      }
+
+      // Build and preview
+      const doc = buildSpecDoc(finalAnswers);
+
+      console.log('\n=== Preview ===\n');
+      console.log(doc);
+
+      const writeConfirm = await ask('Write this to .evolve/spec.md? (yes / no) ');
+      if (writeConfirm.toLowerCase().trim() !== 'yes' && writeConfirm.toLowerCase().trim() !== 'y') {
+        console.log('Aborted. Nothing was written.');
+        return;
+      }
+
+      // Ensure .evolve/ exists
+      if (!isInitialized()) {
+        fs.mkdirSync(getEvolveDir(), { recursive: true });
+      }
+
+      fs.writeFileSync(evolveFile('spec.md'), doc);
+      console.log('');
+      console.log('Written to .evolve/spec.md');
+      console.log('');
+      console.log('Next: run `code-evolve run` to start building the first feature.');
+    } finally {
+      rl.close();
+    }
+  });
+
+async function runInterview(
+  ask: (q: string) => Promise<string>,
+  previous?: SpecAnswers,
+): Promise<SpecAnswers> {
+  const answers: SpecAnswers = previous
+    ? { ...previous, features: [...previous.features] }
+    : {
+        techStack: '',
+        architecture: '',
+        features: [],
+        dataModel: '',
+        apiDesign: '',
+        testing: '',
+        deployment: '',
+      };
+
+  async function askQuestion(
+    key: Exclude<keyof SpecAnswers, 'features'>,
+    question: string,
+    followUp?: string,
+  ): Promise<void> {
+    const prev = previous ? answers[key] : '';
+    if (prev) {
+      console.log(`${question}`);
+      console.log(`  (previous: "${prev.slice(0, 80)}${prev.length > 80 ? '...' : ''}")`);
+    } else {
+      console.log(`${question}`);
+    }
+
+    const answer = await ask('  > ');
+    const trimmed = answer.trim();
+
+    if (trimmed === '' && prev) {
+      return;
+    }
+
+    if (trimmed.toLowerCase() === 'skip' || trimmed === '') {
+      answers[key] = prev || '(to be determined)';
+      return;
+    }
+
+    if (trimmed.toLowerCase() === "i don't know" || trimmed.toLowerCase() === 'not sure') {
+      answers[key] = '(to be determined)';
+      return;
+    }
+
+    if (followUp && trimmed.split(/\s+/).length < 5) {
+      console.log(`  ${followUp}`);
+      const more = await ask('  > ');
+      const moreTrimmed = more.trim();
+      if (moreTrimmed && moreTrimmed.toLowerCase() !== 'skip') {
+        answers[key] = `${trimmed}. ${moreTrimmed}`;
+      } else {
+        answers[key] = trimmed;
+      }
+    } else {
+      answers[key] = trimmed;
+    }
+  }
+
+  // Round 1 — The Stack
+  console.log('--- Round 1: The Stack ---\n');
+  await askQuestion(
+    'techStack',
+    'What\'s your tech stack? Language, framework, database, key libraries.',
+    'Anything else in the stack — runtime, package manager, hosting?',
+  );
+  await askQuestion(
+    'architecture',
+    'How is it structured? (e.g. CLI tool, monolith web app, microservices, library)',
+    'How do the pieces fit together?',
+  );
+
+  // Round 2 — The Features (priority order)
+  console.log('\n--- Round 2: Features (priority order) ---\n');
+  answers.features = await askFeatures(ask, previous ? answers.features : []);
+
+  // Round 3 — The Data
+  console.log('\n--- Round 3: Data & API ---\n');
+  await askQuestion(
+    'dataModel',
+    'What does the data look like? Main entities and how they\'re stored.',
+    'Any key relationships or fields?',
+  );
+  await askQuestion(
+    'apiDesign',
+    'Is there an API or interface? Describe its shape (REST routes, CLI commands, function exports).',
+    'What are the main entry points?',
+  );
+
+  // Round 4 — Quality & Delivery
+  console.log('\n--- Round 4: Quality & Delivery ---\n');
+  await askQuestion(
+    'testing',
+    'What\'s the testing strategy? Frameworks and coverage target.',
+    'Unit, integration, e2e — what matters most here?',
+  );
+  await askQuestion(
+    'deployment',
+    'Where and how does this ship? Deployment target.',
+    'How does it get released?',
+  );
+
+  return answers;
+}
+
+async function askFeatures(
+  ask: (q: string) => Promise<string>,
+  previous: Feature[],
+): Promise<Feature[]> {
+  if (previous.length > 0) {
+    console.log('Current features (press Enter to keep them as-is, or type "redo" to re-enter the list):');
+    for (const f of previous) {
+      console.log(`  - [${f.status}] ${f.text}`);
+    }
+    const choice = (await ask('  > ')).trim().toLowerCase();
+    if (choice !== 'redo') {
+      return previous;
+    }
+    console.log('');
+  }
+
+  console.log('List your features in priority order — the agent builds them top to bottom.');
+  console.log('Enter one per line. Press Enter on an empty line when done.');
+  const features: Feature[] = [];
+  for (;;) {
+    const line = (await ask(`  ${features.length + 1}. `)).trim();
+    if (line === '') break;
+    features.push({ status: ' ', text: line });
+  }
+  return features;
+}
+
+function printSummary(answers: SpecAnswers): void {
+  console.log(`  Tech stack: ${answers.techStack || '(none)'}`);
+  console.log(`  Architecture: ${answers.architecture || '(none)'}`);
+  console.log(`  Features (${answers.features.length}):`);
+  for (const f of answers.features) {
+    console.log(`    - [${f.status}] ${f.text}`);
+  }
+  console.log(`  Data model: ${answers.dataModel || '(none)'}`);
+  console.log(`  API design: ${answers.apiDesign || '(none)'}`);
+  console.log(`  Testing: ${answers.testing || '(none)'}`);
+  console.log(`  Deployment: ${answers.deployment || '(none)'}`);
+}
+
+function extractSection(content: string, heading: string): string {
+  const pattern = new RegExp(`^#+ ${heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'm');
+  const match = pattern.exec(content);
+  if (!match || match.index === undefined) return '';
+  const start = match.index + match[0].length;
+  const nextHeading = content.slice(start).search(/^#+\s/m);
+  const end = nextHeading === -1 ? undefined : start + nextHeading;
+  return content.slice(start, end).trim();
+}
+
+function parseFeatures(section: string): Feature[] {
+  const features: Feature[] = [];
+  const linePattern = /^\s*-\s*\[([ ~xX])\]\s*(.+?)\s*$/;
+  for (const line of section.split('\n')) {
+    const m = linePattern.exec(line);
+    if (m) {
+      const status = (m[1].toLowerCase() === 'x' ? 'x' : m[1]) as FeatureStatus;
+      features.push({ status, text: m[2] });
+    }
+  }
+  return features;
+}
+
+function parseSpecDoc(content: string): SpecAnswers {
+  return {
+    techStack: extractSection(content, 'Tech Stack'),
+    architecture: extractSection(content, 'Architecture'),
+    features: parseFeatures(extractSection(content, 'Features (Priority Order)')),
+    dataModel: extractSection(content, 'Data Model'),
+    apiDesign: extractSection(content, 'API Design'),
+    testing: extractSection(content, 'Testing'),
+    deployment: extractSection(content, 'Deployment'),
+  };
+}
+
+function buildSpecDoc(answers: SpecAnswers): string {
+  const featureLines = answers.features.length
+    ? answers.features.map((f) => `- [${f.status}] ${f.text}`).join('\n')
+    : '- [ ] (add your first feature)';
+
+  return `# Specification
+
+## Tech Stack
+${answers.techStack || '(to be determined)'}
+
+## Architecture
+${answers.architecture || '(to be determined)'}
+
+## Features (Priority Order)
+${featureLines}
+
+## Data Model
+${answers.dataModel || '(to be determined)'}
+
+## API Design
+${answers.apiDesign || '(to be determined)'}
+
+## Testing
+${answers.testing || '(to be determined)'}
+
+## Deployment
+${answers.deployment || '(to be determined)'}
+`;
+}

--- a/tests/test_spec_command.sh
+++ b/tests/test_spec_command.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Test: `code-evolve spec` runs an interview and writes a populated .evolve/spec.md,
+# and `code-evolve spec --refine` reloads, edits, and preserves checkbox state.
+# Regression test for issue #21 (P1.2).
+#
+# Drives the REAL compiled CLI over piped (non-TTY) stdin — no API key or agent needed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+# Build if the CLI isn't compiled yet.
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+# ── Case 1: fresh interview writes a populated spec with checkbox features ──
+T1=$(mktemp -d)
+( cd "$T1"
+  printf '%s\n' \
+    "TypeScript Node.js Commander SQLite Jest" \
+    "A CLI tool using command pattern" \
+    "Add task command" "List all tasks command" "Mark a task done command" "" \
+    "Tasks stored as markdown files locally" \
+    "CLI subcommands add list and done" \
+    "Jest unit tests with coverage target" \
+    "Published to the npm registry package" \
+    "yes" "yes" | node "$CLI" spec >/dev/null 2>&1
+) || echo CRASH > "$T1/crash"
+check "fresh run does not crash" "$( [ -f "$T1/crash" ] && echo CRASH || echo OK )" "OK"
+check "fresh run writes spec.md" "$( [ -f "$T1/.evolve/spec.md" ] && echo YES || echo NO )" "YES"
+check "tech stack captured" "$(grep -c 'TypeScript Node.js Commander' "$T1/.evolve/spec.md" || true)" "1"
+check "features rendered as checkboxes" "$(grep -c '^- \[ \] Add task command' "$T1/.evolve/spec.md" || true)" "1"
+
+# ── Case 2: --refine reloads, edits one field, preserves checkbox state ──
+sed -i 's/- \[ \] Add task command/- [x] Add task command/' "$T1/.evolve/spec.md"
+( cd "$T1"
+  # change tech stack; blank = keep for every other prompt (incl. "keep features")
+  printf '%s\n' "Rust with Cargo and Clap framework" "" "" "" "" "" "" "yes" "yes" \
+    | node "$CLI" spec --refine >/dev/null 2>&1
+) || echo CRASH > "$T1/crash2"
+check "refine does not crash" "$( [ -f "$T1/crash2" ] && echo CRASH || echo OK )" "OK"
+check "refine applied the edit" "$(grep -c 'Rust with Cargo and Clap' "$T1/.evolve/spec.md" || true)" "1"
+check "refine preserved [x] checkbox" "$(grep -c '^- \[x\] Add task command' "$T1/.evolve/spec.md" || true)" "1"
+check "refine kept untouched field" "$(grep -c 'A CLI tool using command pattern' "$T1/.evolve/spec.md" || true)" "1"
+rm -rf "$T1"
+
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds a `code-evolve spec` command that mirrors the existing `code-evolve vision` interview, closing the onboarding gap where `spec.md` had to be written by hand from a blank template.

- Interactive interview: **tech stack → architecture → prioritized feature list (checkbox format) → data model → API design → testing → deployment**, written to `.evolve/spec.md`.
- `--refine` reloads the existing spec, shows prior answers (Enter = keep), and **preserves per-feature checkbox state** (`[ ]` / `[~]` / `[x]`) so refining doesn't reset build progress.
- Wired into `cli.ts`.

## Implementation note

`vision.ts`'s readline pattern (one promise per `rl.question`) loses buffered lines and `process.exit(0)`s on EOF, so it can't be driven non-interactively. `spec.ts` uses a small **line-queue reader** instead: decoupled from readline's emit pace, no lost lines on piped input, EOF resolves pending prompts to `''`. Same interactive UX, plus it's testable.

## Verification

`tests/test_spec_command.sh` drives the real compiled CLI over piped stdin (no API key / agent needed):

```
ok: fresh run writes spec.md
ok: tech stack captured
ok: features rendered as checkboxes
ok: refine applied the edit
ok: refine preserved [x] checkbox
ok: refine kept untouched field
passed: 8  failed: 0
```

`npm run lint` (tsc) clean; existing `test_greenfield_guard.sh` still 8/8.

## Acceptance criteria

- [x] `code-evolve spec` produces a populated `.evolve/spec.md` from answers
- [x] `code-evolve spec --refine` reloads and edits the existing file

## Known limitations

- The interview is scripted, not LLM-driven — that's the explicitly-separate **P1.4** (#23). This PR matches the current `vision.ts` behavior.

Closes #21

https://claude.ai/code/session_016XyForheNz53b78vTfkC7v