### PR TITLE
feat(init): offer vision + spec interviews after install (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ All commands are available as both `code-evolve <cmd>` and `ce <cmd>`.
 |---------|-------------|
 | `code-evolve init` | Scaffold `.evolve/` with vision and spec templates |
 | `code-evolve vision` | Guided Socratic interview to generate `.evolve/vision.md` |
+| `code-evolve spec` | Guided interview to generate `.evolve/spec.md` |
 | `code-evolve migrate` | Convert an existing spec/vision document into code-evolve format |
 | `code-evolve start` | Turn on the evolution engine (local cron) |
 | `code-evolve stop` | Pause evolution |
@@ -182,6 +183,16 @@ code-evolve init --force                 # upgrade framework files (preserves jo
 code-evolve vision           # guided interview to create .evolve/vision.md
 code-evolve vision --refine  # revisit and improve an existing vision.md
 ```
+
+### `spec`
+
+```bash
+code-evolve spec           # guided interview to create .evolve/spec.md
+code-evolve spec --refine  # revisit and improve an existing spec.md
+```
+
+On a terminal, `code-evolve init` offers to run the `vision` and `spec`
+interviews for you right after install — decline to edit the files by hand instead.
 
 ### `migrate`
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
@@ -213,17 +214,75 @@ export const initCommand = new Command('init')
     console.log('');
     console.log('code-evolve initialized.');
     console.log('');
+
+    // On a TTY, offer to run the vision + spec interviews right now so onboarding
+    // flows straight into artifact generation. Declining (or non-TTY) falls through
+    // to the manual "edit these files" guidance below — scripted/CI installs are
+    // never prompted. We only drop the manual step for a file the interview
+    // actually populated, so a cancelled interview still gets its "edit" reminder.
+    let visionDone = false;
+    let specDone = false;
+    if (interactive) {
+      const launch = await promptYesNo('Generate your vision + spec now via a guided interview? (yes/no): ');
+      if (launch) {
+        visionDone = runInterview('vision');
+        specDone = runInterview('spec');
+        console.log('');
+      }
+    }
+
     console.log('Next steps:');
-    console.log('  1. Edit .evolve/vision.md with your project vision');
-    console.log('  2. Edit .evolve/spec.md with your technical specification');
-    console.log(`  3. ${getAgentEnvHint(agent, authMode)}`);
-    console.log('  4. Run: code-evolve run');
+    let step = 1;
+    if (!visionDone) {
+      console.log(`  ${step++}. Edit .evolve/vision.md with your project vision`);
+    }
+    if (!specDone) {
+      console.log(`  ${step++}. Edit .evolve/spec.md with your technical specification`);
+    }
+    console.log(`  ${step++}. ${getAgentEnvHint(agent, authMode)}`);
+    console.log(`  ${step++}. Run: code-evolve run`);
     if (!options.withCi) {
       console.log('');
       console.log('  To add GitHub Actions (auto-evolve every 4h):');
       console.log('    code-evolve init --with-ci --force');
     }
   });
+
+/** Ask a yes/no question on the current TTY. Defaults to no on empty/EOF. */
+async function promptYesNo(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise<string>((resolve) => {
+      // EOF (Ctrl-D / closed TTY) fires 'close' without ever calling the
+      // question callback — resolve empty so we follow the declined path.
+      rl.on('close', () => resolve(''));
+      rl.question(question, resolve);
+    });
+    const normalized = answer.trim().toLowerCase();
+    return normalized === 'y' || normalized === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Launch one of the interview subcommands (`vision`/`spec`) by re-invoking this
+ * same CLI as a child process with inherited stdio, so it owns the terminal
+ * cleanly. Returns true only if the interview actually populated the target file
+ * (the user can cancel mid-interview and exit 0), so callers know whether the
+ * manual "edit this file" guidance is still needed.
+ */
+function runInterview(name: 'vision' | 'spec'): boolean {
+  const file = evolveFile(`${name}.md`);
+  const read = (): string => (fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '');
+  const before = read();
+  const res = spawnSync(process.execPath, [process.argv[1], name], { stdio: 'inherit' });
+  if (res.status !== 0) {
+    console.warn(`  (${name} interview did not complete — run \`code-evolve ${name}\` anytime.)`);
+  }
+  const after = read();
+  return after.trim() !== '' && after !== before;
+}
 
 /** Copy directory recursively, overwriting all files (for framework code). */
 function copyDir(src: string, dest: string): void {

--- a/tests/_drive_init_pty.py
+++ b/tests/_drive_init_pty.py
@@ -42,13 +42,18 @@ else:  # decline
     ]
 
 idx = 0
+buf = ""  # accumulate output across reads so a prompt split over two PTY reads
+          # (e.g. "guided interv" + "iew") still matches
 
 
-def handle(text: str, write) -> None:
-    global idx
-    while idx < len(steps) and steps[idx][0] in text:
+def handle(write) -> None:
+    """Match the next expected step against accumulated output. Clearing the
+    buffer after each answer both prevents re-firing and bounds its growth."""
+    global idx, buf
+    if idx < len(steps) and steps[idx][0] in buf:
         write(steps[idx][1])
         idx += 1
+        buf = ""
 
 
 pid, fd = pty.fork()
@@ -69,5 +74,6 @@ else:  # parent: pump output, answer prompts
         if not chunk:
             break
         os.write(1, chunk)
-        handle(chunk.decode("utf-8", "replace"), lambda b: os.write(fd, b))
+        buf += chunk.decode("utf-8", "replace")
+        handle(lambda b: os.write(fd, b))
     os.waitpid(pid, 0)

--- a/tests/_drive_init_pty.py
+++ b/tests/_drive_init_pty.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Drive `code-evolve init` under a real pty, answering its interactive prompts.
+
+Spawns the compiled CLI with a controlling terminal (so init's `isTTY` checks
+are true), then feeds canned answers as each prompt appears. Two modes:
+
+  decline  agent->1, auth->1, interview offer->"no"
+  cancel   agent->1, auth->1, interview offer->"yes", then Ctrl-D to cancel each
+           launched interview (vision, then spec)
+
+All terminal output is echoed to our stdout so the caller can grep it.
+Usage: _drive_init_pty.py <cli.js> <decline|cancel>
+"""
+import os
+import pty
+import select
+import sys
+
+cli, mode = sys.argv[1], sys.argv[2]
+
+# Ordered (substring, response) steps; each fires at most once, in order.
+EOF = b"\x04"  # Ctrl-D -> readline 'close' -> interview cancels
+if mode == "cancel":
+    steps = [
+        ("Select [1-4]", b"1\n"),
+        ("Select [1-2]", b"1\n"),
+        ("guided interview", b"yes\n"),
+        ("Vision Interview", EOF),
+        ("Spec Interview", EOF),
+    ]
+elif mode == "eof":  # press Ctrl-D at the offer prompt instead of answering
+    steps = [
+        ("Select [1-4]", b"1\n"),
+        ("Select [1-2]", b"1\n"),
+        ("guided interview", EOF),
+    ]
+else:  # decline
+    steps = [
+        ("Select [1-4]", b"1\n"),
+        ("Select [1-2]", b"1\n"),
+        ("guided interview", b"no\n"),
+    ]
+
+idx = 0
+
+
+def handle(text: str, write) -> None:
+    global idx
+    while idx < len(steps) and steps[idx][0] in text:
+        write(steps[idx][1])
+        idx += 1
+
+
+pid, fd = pty.fork()
+if pid == 0:  # child: exec the CLI with the pty as its controlling terminal
+    os.execvp("node", ["node", cli, "init"])
+else:  # parent: pump output, answer prompts
+    while True:
+        try:
+            r, _, _ = select.select([fd], [], [], 10)
+        except (OSError, ValueError):
+            break
+        if not r:
+            break
+        try:
+            chunk = os.read(fd, 1024)
+        except OSError:
+            break
+        if not chunk:
+            break
+        os.write(1, chunk)
+        handle(chunk.decode("utf-8", "replace"), lambda b: os.write(fd, b))
+    os.waitpid(pid, 0)

--- a/tests/test_init_offer.sh
+++ b/tests/test_init_offer.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Test: `code-evolve init` offers the vision + spec interviews on a TTY, but on
+# piped (non-TTY) stdin it stays silent and keeps the manual "edit these files"
+# guidance — so CI / scripted installs are unaffected.
+# Regression test for issue #22 (P1.3).
+#
+# Drives the REAL compiled CLI. A stub `claude` on PATH satisfies the dependency
+# check; no API key or real agent is needed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+# Stub agent binary so checkDependencies('claude') passes without a real CLI.
+STUB=$(mktemp -d)
+cat > "$STUB/claude" <<'EOF'
+#!/bin/bash
+echo "claude 0.0.0-stub"
+EOF
+chmod +x "$STUB/claude"
+export PATH="$STUB:$PATH"
+
+# ── Case 1: non-TTY init does NOT offer interviews, keeps manual guidance ──
+T1=$(mktemp -d)
+( cd "$T1" && git init -q )
+OUT1=$( cd "$T1" && node "$CLI" init </dev/null 2>&1 ) || true
+check "non-TTY keeps manual vision guidance" "$(echo "$OUT1" | grep -c 'Edit .evolve/vision.md' || true)" "1"
+check "non-TTY does not offer interview"      "$(echo "$OUT1" | grep -ci 'guided interview' || true)" "0"
+rm -rf "$T1"
+
+# ── Case 2 (pty): on a TTY, init offers the interviews; declining keeps guidance ──
+# A Python helper drives the real pty, answering the agent/auth pickers then
+# declining the interview offer. python3 is already a hard dependency.
+T2=$(mktemp -d)
+( cd "$T2" && git init -q )
+OUT2=$( cd "$T2" && python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" decline 2>&1 ) || true
+check "TTY offers the interview"        "$(echo "$OUT2" | grep -ci 'guided interview' || true)" "1"
+check "declining keeps manual guidance" "$(echo "$OUT2" | grep -c 'Edit .evolve/vision.md' || true)" "1"
+rm -rf "$T2"
+
+# ── Case 3 (pty): accept the offer but cancel the interviews -> guidance stays ──
+# Accepting and then bailing out of each interview must NOT suppress the manual
+# "edit these files" steps (the files are still empty templates). Regression
+# guard for the per-file completion check.
+T3=$(mktemp -d)
+( cd "$T3" && git init -q )
+OUT3=$( cd "$T3" && python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" cancel 2>&1 ) || true
+check "cancelled vision keeps its edit step" "$(echo "$OUT3" | grep -c 'Edit .evolve/vision.md' || true)" "1"
+check "cancelled spec keeps its edit step"   "$(echo "$OUT3" | grep -c 'Edit .evolve/spec.md' || true)" "1"
+rm -rf "$T3"
+
+# ── Case 4 (pty): EOF (Ctrl-D) at the offer prompt follows the declined path ──
+# Pressing Ctrl-D must not hang init — it defaults to "no" and still prints guidance.
+T4=$(mktemp -d)
+( cd "$T4" && git init -q )
+OUT4=$( cd "$T4" && timeout 20 python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" eof 2>&1 ) || true
+check "EOF at offer still prints Next steps" "$(echo "$OUT4" | grep -c 'Next steps' || true)" "1"
+rm -rf "$T4"
+
+rm -rf "$STUB"
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/tests/test_init_offer.sh
+++ b/tests/test_init_offer.sh
@@ -38,7 +38,7 @@ rm -rf "$T1"
 # declining the interview offer. python3 is already a hard dependency.
 T2=$(mktemp -d)
 ( cd "$T2" && git init -q )
-OUT2=$( cd "$T2" && python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" decline 2>&1 ) || true
+OUT2=$( cd "$T2" && timeout 20 python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" decline 2>&1 ) || true
 check "TTY offers the interview"        "$(echo "$OUT2" | grep -ci 'guided interview' || true)" "1"
 check "declining keeps manual guidance" "$(echo "$OUT2" | grep -c 'Edit .evolve/vision.md' || true)" "1"
 rm -rf "$T2"
@@ -49,7 +49,7 @@ rm -rf "$T2"
 # guard for the per-file completion check.
 T3=$(mktemp -d)
 ( cd "$T3" && git init -q )
-OUT3=$( cd "$T3" && python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" cancel 2>&1 ) || true
+OUT3=$( cd "$T3" && timeout 20 python3 "$ROOT/tests/_drive_init_pty.py" "$CLI" cancel 2>&1 ) || true
 check "cancelled vision keeps its edit step" "$(echo "$OUT3" | grep -c 'Edit .evolve/vision.md' || true)" "1"
 check "cancelled spec keeps its edit step"   "$(echo "$OUT3" | grep -c 'Edit .evolve/spec.md' || true)" "1"
 rm -rf "$T3"


### PR DESCRIPTION
Closes #22 (P1.3).

## What

After `code-evolve init` on a terminal, it now offers to launch the guided
**vision** and **spec** interviews immediately, so onboarding flows straight
from install into artifact generation. Declining — or any non-TTY / scripted /
CI install — keeps the existing "edit `.evolve/vision.md` / `.evolve/spec.md`"
guidance unchanged.

Dependencies P1.1 (agent/auth picker, #20) and P1.2 (`spec` command, #21) are
already merged.

## How

- `src/commands/init.ts`: after config is written and only when interactive,
  prompt yes/no, then re-invoke this same CLI as a child process
  (`spawnSync`, inherited stdio) for `vision` then `spec`.
- The manual "edit this file" next-step is dropped **per file** only when the
  interview actually populated it (compares file content before/after), so a
  cancelled interview still gets its reminder.
- EOF (Ctrl-D) at the offer prompt resolves to "no" rather than hanging.
- `README.md`: documents `code-evolve spec` (table + section) and the new
  init-time offer.

## Tests

`tests/test_init_offer.sh` drives the **real** compiled CLI:
- non-TTY (piped) init stays silent and keeps manual guidance,
- TTY offer appears, decline keeps guidance,
- accept-then-cancel keeps both edit steps (per-file completion check),
- EOF at the offer still prints Next steps.

A small Python pty driver (`tests/_drive_init_pty.py`) provides the controlling
terminal; python3 is already a hard dependency. Existing suites
(`test_greenfield_guard.sh`, `test_spec_command.sh`) still pass.

## Known limitations

- The full "accept → populated vision + spec" happy path is exercised manually
  (the automated pty tests cover decline/cancel/EOF, not a full interview run).
- Cross-family review via `codex review` (two findings addressed: per-file
  guidance suppression, EOF handling).

https://claude.ai/code/session_016XyForheNz53b78vTfkC7v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `init` can now offer to run guided `vision` and `spec` interviews during setup in interactive terminals.
  * `code-evolve spec` is now included in the commands list, with usage guidance added.

* **Documentation**
  * Expanded the setup docs with a dedicated `spec` section and updated next-step guidance after initialization.

* **Tests**
  * Added regression coverage for interactive and non-interactive `init` flows, including decline, cancel, and EOF handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->