### PR TITLE
feat(interview): LLM-driven vision/spec drafting via configured agent (P1.4, #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 
 # Local Claude Code state (machine-local, not project data)
 .claude/
+
+# Local planning notes (not part of the package)
+tasks/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ code-evolve vision
 code-evolve spec
 ```
 
-`vision` runs five rounds of Socratic questions — what you're building, who it's for, what problem it solves, and what success looks like — assembled into `.evolve/vision.md` with your approval. `spec` then interviews you on tech stack, architecture, and a prioritized feature checklist, written to `.evolve/spec.md`. Re-run either with `--refine` to revisit prior answers.
+`vision` runs five rounds of Socratic questions — what you're building, who it's for, what problem it solves, and what success looks like. `spec` then interviews you on tech stack, architecture, and a prioritized feature checklist. When an agent is configured (see [Multi-Agent Support](#multi-agent-support)), your configured LLM drafts the `.evolve/vision.md` / `.evolve/spec.md` from your answers and you can accept it or ask for a refinement; with no agent configured it falls back to a built-in template. Re-run either with `--refine` to revisit prior answers.
 
 **Option B: Write both files directly**
 

--- a/src/commands/spec.ts
+++ b/src/commands/spec.ts
@@ -2,6 +2,8 @@ import { Command } from 'commander';
 import fs from 'fs';
 import readline from 'readline';
 import { evolveFile, getEvolveDir, isInitialized } from '../utils/paths';
+import { makeAsk } from '../utils/interview';
+import { draftWithAgent } from '../utils/agent';
 
 type FeatureStatus = ' ' | '~' | 'x';
 
@@ -25,28 +27,7 @@ export const specCommand = new Command('spec')
   .option('--refine', 'Revisit and improve an existing spec.md')
   .action(async (options: { refine?: boolean }) => {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-
-    // Line-queue reader: decouples our await pace from readline's emit pace so
-    // piped (non-TTY) input isn't lost between questions, and EOF resolves
-    // pending prompts to '' instead of leaving the process hung.
-    const queue: string[] = [];
-    const waiters: Array<(line: string) => void> = [];
-    let closed = false;
-    rl.on('line', (line) => {
-      const waiter = waiters.shift();
-      if (waiter) waiter(line);
-      else queue.push(line);
-    });
-    rl.on('close', () => {
-      closed = true;
-      while (waiters.length) waiters.shift()!('');
-    });
-    const ask = (question: string): Promise<string> => {
-      process.stdout.write(question);
-      if (queue.length) return Promise.resolve(queue.shift()!);
-      if (closed) return Promise.resolve('');
-      return new Promise((resolve) => waiters.push(resolve));
-    };
+    const ask = makeAsk(rl);
 
     try {
       console.log('');
@@ -97,14 +78,37 @@ export const specCommand = new Command('spec')
         printSummary(finalAnswers);
       }
 
-      // Build and preview
-      const doc = buildSpecDoc(finalAnswers);
+      // Draft with the configured agent; fall back to the static template when
+      // no agent/key is available.
+      console.log('\nDrafting your spec...');
+      let drafted = draftWithAgent(buildSpecPrompt(finalAnswers));
+      console.log(drafted ? '(Drafted with your configured agent.)' : '(No agent configured — using the built-in template.)');
+      let doc = drafted ?? buildSpecDoc(finalAnswers);
 
-      console.log('\n=== Preview ===\n');
-      console.log(doc);
+      // Preview + accept/refine loop.
+      for (;;) {
+        console.log('\n=== Preview ===\n');
+        console.log(doc);
 
-      const writeConfirm = await ask('Write this to .evolve/spec.md? (yes / no) ');
-      if (writeConfirm.toLowerCase().trim() !== 'yes' && writeConfirm.toLowerCase().trim() !== 'y') {
+        const prompt = drafted
+          ? 'Write this to .evolve/spec.md? (yes / refine / no) '
+          : 'Write this to .evolve/spec.md? (yes / no) ';
+        const choice = (await ask(prompt)).toLowerCase().trim();
+
+        if (choice === 'yes' || choice === 'y') break;
+
+        if (drafted && (choice === 'refine' || choice === 'r')) {
+          const feedback = (await ask('What should change? ')).trim();
+          const redo = draftWithAgent(buildSpecPrompt(finalAnswers, feedback));
+          if (redo) {
+            drafted = redo;
+            doc = redo;
+          } else {
+            console.log('Could not redraft — keeping the current version.');
+          }
+          continue;
+        }
+
         console.log('Aborted. Nothing was written.');
         return;
       }
@@ -332,5 +336,47 @@ ${answers.testing || '(to be determined)'}
 
 ## Deployment
 ${answers.deployment || '(to be determined)'}
+`;
+}
+
+function buildSpecPrompt(answers: SpecAnswers, feedback?: string): string {
+  const featureLines = answers.features.length
+    ? answers.features.map((f) => `- [${f.status}] ${f.text}`).join('\n')
+    : '- [ ] (no features given)';
+
+  return `You are drafting a technical specification from a developer interview.
+Write a clear, well-structured spec in GitHub-flavored Markdown.
+
+Use EXACTLY these headings, in this order, and nothing else:
+# Specification
+## Tech Stack
+## Architecture
+## Features (Priority Order)
+## Data Model
+## API Design
+## Testing
+## Deployment
+
+Sharpen and organize each section from the answers below; do not invent facts
+the answers do not imply. For any empty answer, write "(to be determined)".
+
+CRITICAL: Under "## Features (Priority Order)", reproduce the feature list
+EXACTLY as given — same order, one per line, each as \`- [<status>] <text>\`
+keeping the status marker ([ ], [~], or [x]) unchanged. This list is parsed by
+the build pipeline, so do not rephrase, reorder, merge, or drop any feature.
+
+Output ONLY the Markdown document — no preamble, no commentary, and do not use
+any tools or write any files.
+${feedback ? `\nRevision request from the user — apply this (but still keep the feature lines verbatim): ${feedback}\n` : ''}
+Interview answers:
+- Tech stack: ${answers.techStack || '(not answered)'}
+- Architecture: ${answers.architecture || '(not answered)'}
+- Data model: ${answers.dataModel || '(not answered)'}
+- API design: ${answers.apiDesign || '(not answered)'}
+- Testing: ${answers.testing || '(not answered)'}
+- Deployment: ${answers.deployment || '(not answered)'}
+
+Features (Priority Order) — reproduce verbatim:
+${featureLines}
 `;
 }

--- a/src/commands/spec.ts
+++ b/src/commands/spec.ts
@@ -78,10 +78,17 @@ export const specCommand = new Command('spec')
         printSummary(finalAnswers);
       }
 
-      // Draft with the configured agent; fall back to the static template when
-      // no agent/key is available.
+      // Draft with the configured agent (and force the feature checklist back to
+      // the user's exact list — the build pipeline parses those lines, so we never
+      // trust the model with them). Falls back to the static template when no
+      // agent/key is available or the draft's structure is unusable.
+      const draftSpec = (feedback?: string): string | null => {
+        const d = draftWithAgent(buildSpecPrompt(finalAnswers, feedback));
+        return d ? enforceFeatureChecklist(d, finalAnswers.features) : null;
+      };
+
       console.log('\nDrafting your spec...');
-      let drafted = draftWithAgent(buildSpecPrompt(finalAnswers));
+      let drafted = draftSpec();
       console.log(drafted ? '(Drafted with your configured agent.)' : '(No agent configured — using the built-in template.)');
       let doc = drafted ?? buildSpecDoc(finalAnswers);
 
@@ -99,7 +106,7 @@ export const specCommand = new Command('spec')
 
         if (drafted && (choice === 'refine' || choice === 'r')) {
           const feedback = (await ask('What should change? ')).trim();
-          const redo = draftWithAgent(buildSpecPrompt(finalAnswers, feedback));
+          const redo = draftSpec(feedback);
           if (redo) {
             drafted = redo;
             doc = redo;
@@ -337,6 +344,30 @@ ${answers.testing || '(to be determined)'}
 ## Deployment
 ${answers.deployment || '(to be determined)'}
 `;
+}
+
+/**
+ * Replace the body of the agent draft's "## Features (Priority Order)" section
+ * with the user's exact checklist, so a model rewrite/drop/reorder can never
+ * corrupt the lines the build pipeline parses. Returns null if the draft has no
+ * such section (structure unusable → caller falls back to the static builder).
+ */
+function enforceFeatureChecklist(doc: string, features: Feature[]): string | null {
+  const canonical = features.length
+    ? features.map((f) => `- [${f.status}] ${f.text}`).join('\n')
+    : '- [ ] (add your first feature)';
+
+  const heading = /^##[ \t]+Features \(Priority Order\)[ \t]*$/m.exec(doc);
+  if (!heading || heading.index === undefined) return null;
+
+  const bodyStart = heading.index + heading[0].length;
+  const rest = doc.slice(bodyStart);
+  const nextHeading = rest.search(/^##[ \t]/m);
+  const bodyEnd = nextHeading === -1 ? doc.length : bodyStart + nextHeading;
+
+  const before = doc.slice(0, bodyStart);
+  const after = doc.slice(bodyEnd);
+  return `${before}\n${canonical}\n\n${after}`.replace(/\n{3,}/g, '\n\n').replace(/\s*$/, '\n');
 }
 
 function buildSpecPrompt(answers: SpecAnswers, feedback?: string): string {

--- a/src/commands/vision.ts
+++ b/src/commands/vision.ts
@@ -2,6 +2,8 @@ import { Command } from 'commander';
 import fs from 'fs';
 import readline from 'readline';
 import { evolveFile, getEvolveDir, isInitialized } from '../utils/paths';
+import { makeAsk } from '../utils/interview';
+import { draftWithAgent } from '../utils/agent';
 
 interface InterviewAnswers {
   whatBuilding: string;
@@ -21,12 +23,7 @@ export const visionCommand = new Command('vision')
   .option('--refine', 'Revisit and improve an existing vision.md')
   .action(async (options: { refine?: boolean }) => {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    rl.on('close', () => {
-      console.log('\nInterview cancelled.');
-      process.exit(0);
-    });
-    const ask = (question: string): Promise<string> =>
-      new Promise((resolve) => rl.question(question, resolve));
+    const ask = makeAsk(rl);
 
     try {
       console.log('');
@@ -77,14 +74,37 @@ export const visionCommand = new Command('vision')
         printSummary(finalAnswers);
       }
 
-      // Build and preview
-      const doc = buildVisionDoc(finalAnswers);
+      // Draft with the configured agent; fall back to the static template when
+      // no agent/key is available.
+      console.log('\nDrafting your vision...');
+      let drafted = draftWithAgent(buildVisionPrompt(finalAnswers));
+      console.log(drafted ? '(Drafted with your configured agent.)' : '(No agent configured — using the built-in template.)');
+      let doc = drafted ?? buildVisionDoc(finalAnswers);
 
-      console.log('\n=== Preview ===\n');
-      console.log(doc);
+      // Preview + accept/refine loop.
+      for (;;) {
+        console.log('\n=== Preview ===\n');
+        console.log(doc);
 
-      const writeConfirm = await ask('Write this to .evolve/vision.md? (yes / no) ');
-      if (writeConfirm.toLowerCase().trim() !== 'yes' && writeConfirm.toLowerCase().trim() !== 'y') {
+        const prompt = drafted
+          ? 'Write this to .evolve/vision.md? (yes / refine / no) '
+          : 'Write this to .evolve/vision.md? (yes / no) ';
+        const choice = (await ask(prompt)).toLowerCase().trim();
+
+        if (choice === 'yes' || choice === 'y') break;
+
+        if (drafted && (choice === 'refine' || choice === 'r')) {
+          const feedback = (await ask('What should change? ')).trim();
+          const redo = draftWithAgent(buildVisionPrompt(finalAnswers, feedback));
+          if (redo) {
+            drafted = redo;
+            doc = redo;
+          } else {
+            console.log('Could not redraft — keeping the current version.');
+          }
+          continue;
+        }
+
         console.log('Aborted. Nothing was written.');
         return;
       }
@@ -322,5 +342,48 @@ ${answers.successSignal}
 
 ### The Delight Moment
 ${answers.delightMoment}
+`;
+}
+
+function buildVisionPrompt(answers: InterviewAnswers, feedback?: string): string {
+  const qa: [string, string][] = [
+    ['What are you building', answers.whatBuilding],
+    ['Who it is for', answers.whoFor],
+    ['The current pain without this tool', answers.currentPain],
+    ['The moment they reach for it', answers.triggerMoment],
+    ['The first experience', answers.firstExperience],
+    ['The one thing it must do well', answers.mustDoWell],
+    ['What it is NOT', answers.notThis],
+    ['What to cut for a one-week MVP', answers.mvpCuts],
+    ['How success is measured', answers.successSignal],
+    ['The delight moment', answers.delightMoment],
+  ];
+  const interview = qa.map(([q, a]) => `- ${q}: ${a || '(not answered)'}`).join('\n');
+
+  return `You are drafting a project vision document from a founder interview.
+Write a clear, compelling vision in GitHub-flavored Markdown.
+
+Use EXACTLY these headings, in this order, and nothing else:
+# Vision
+## What We're Building
+## Who It's For
+## The Problem
+### The Trigger
+## The Experience
+### Core Capability
+## Boundaries
+### MVP Scope
+## Success
+### The Delight Moment
+
+Base each section on the interview answers below. Sharpen the language and flow,
+but do not invent facts that the answers do not imply. For any answer that is
+empty or "(to be determined)", write a short honest placeholder.
+
+Output ONLY the Markdown document — no preamble, no commentary, and do not use
+any tools or write any files.
+${feedback ? `\nRevision request from the user — apply this: ${feedback}\n` : ''}
+Interview answers:
+${interview}
 `;
 }

--- a/src/utils/agent.ts
+++ b/src/utils/agent.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getEvolveDir } from './paths';
+import { readConfig, getAgentEnvKey, getDefaultModel, isValidAgent } from './config';
+
+/**
+ * Draft a document by routing `prompt` through the configured agent adapter
+ * (`.evolve/scripts/agents/<agent>.sh`) — the same `run_agent` entry point
+ * `evolve.sh` uses to invoke the agent.
+ *
+ * Returns the agent's text output, or `null` when no agent is usable (adapter
+ * missing, required API key unset, or the call fails/times out). Callers fall
+ * back to their static builder on `null`.
+ */
+export function draftWithAgent(prompt: string): string | null {
+  const config = readConfig();
+  const agent = config.agent || 'claude';
+  if (!isValidAgent(agent)) return null;
+
+  const adapter = path.join(getEvolveDir(), 'scripts', 'agents', `${agent}.sh`);
+  if (!fs.existsSync(adapter)) return null;
+
+  const envKey = getAgentEnvKey(agent, config.authMode);
+  if (envKey && !process.env[envKey]) return null;
+
+  const model = config.model || getDefaultModel(agent);
+  const promptFile = path.join(os.tmpdir(), `code-evolve-draft-${process.pid}.txt`);
+
+  try {
+    fs.writeFileSync(promptFile, prompt);
+    // Source the adapter and call its run_agent(prompt_file, model, timeout_cmd, timeout).
+    // No timeout_cmd is passed; spawnSync's own timeout guards against a hung agent.
+    const result = spawnSync(
+      'bash',
+      ['-c', 'source "$1"; run_agent "$2" "$3" "" ""', 'bash', adapter, promptFile, model],
+      {
+        encoding: 'utf8',
+        maxBuffer: 16 * 1024 * 1024,
+        timeout: 300_000,
+        killSignal: 'SIGTERM',
+        env: {
+          ...process.env,
+          ...(config.authMode === 'oauth' ? { CLAUDE_AUTH_MODE: 'oauth' } : {}),
+        },
+      },
+    );
+    if (result.status !== 0 || result.error) return null;
+    const out = (result.stdout || '').trim();
+    return out.length ? out : null;
+  } catch {
+    return null;
+  } finally {
+    fs.rmSync(promptFile, { force: true });
+  }
+}

--- a/src/utils/agent.ts
+++ b/src/utils/agent.ts
@@ -26,19 +26,36 @@ export function draftWithAgent(prompt: string): string | null {
   if (envKey && !process.env[envKey]) return null;
 
   const model = config.model || getDefaultModel(agent);
-  const promptFile = path.join(os.tmpdir(), `code-evolve-draft-${process.pid}.txt`);
+  // Per-call private dir (not a guessable shared-tmp name), prompt written 0600 —
+  // interview prompts can carry sensitive product details.
+  let promptDir: string;
+  try {
+    promptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'code-evolve-draft-'));
+  } catch {
+    return null;
+  }
+  const promptFile = path.join(promptDir, 'prompt.txt');
 
   try {
-    fs.writeFileSync(promptFile, prompt);
-    // Source the adapter and call its run_agent(prompt_file, model, timeout_cmd, timeout).
-    // No timeout_cmd is passed; spawnSync's own timeout guards against a hung agent.
+    fs.writeFileSync(promptFile, prompt, { mode: 0o600 });
+    // Source the adapter and call run_agent(prompt_file, model, timeout_cmd, timeout).
+    // A detected `timeout`/`gtimeout` wrapper (the same mechanism evolve.sh uses)
+    // kills the agent's whole process tree on timeout; spawnSync's own timeout is
+    // an outer backstop in case neither binary exists.
     const result = spawnSync(
       'bash',
-      ['-c', 'source "$1"; run_agent "$2" "$3" "" ""', 'bash', adapter, promptFile, model],
+      [
+        '-c',
+        'tcmd="$(command -v timeout || command -v gtimeout || true)"; source "$1"; run_agent "$2" "$3" "$tcmd" 300',
+        'bash',
+        adapter,
+        promptFile,
+        model,
+      ],
       {
         encoding: 'utf8',
         maxBuffer: 16 * 1024 * 1024,
-        timeout: 300_000,
+        timeout: 330_000,
         killSignal: 'SIGTERM',
         env: {
           ...process.env,
@@ -52,6 +69,6 @@ export function draftWithAgent(prompt: string): string | null {
   } catch {
     return null;
   } finally {
-    fs.rmSync(promptFile, { force: true });
+    fs.rmSync(promptDir, { recursive: true, force: true });
   }
 }

--- a/src/utils/interview.ts
+++ b/src/utils/interview.ts
@@ -1,0 +1,32 @@
+import readline from 'readline';
+
+/**
+ * Build an `ask(question)` helper over a readline interface that works for both
+ * interactive (TTY) and piped (non-TTY) input.
+ *
+ * A line-queue decouples our await pace from readline's emit pace, so piped
+ * input isn't dropped between questions, and EOF resolves any pending prompt to
+ * '' instead of leaving the process hung.
+ */
+export function makeAsk(rl: readline.Interface): (question: string) => Promise<string> {
+  const queue: string[] = [];
+  const waiters: Array<(line: string) => void> = [];
+  let closed = false;
+
+  rl.on('line', (line) => {
+    const waiter = waiters.shift();
+    if (waiter) waiter(line);
+    else queue.push(line);
+  });
+  rl.on('close', () => {
+    closed = true;
+    while (waiters.length) waiters.shift()!('');
+  });
+
+  return (question: string): Promise<string> => {
+    process.stdout.write(question);
+    if (queue.length) return Promise.resolve(queue.shift()!);
+    if (closed) return Promise.resolve('');
+    return new Promise((resolve) => waiters.push(resolve));
+  };
+}

--- a/tests/test_llm_interview.sh
+++ b/tests/test_llm_interview.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Test: `code-evolve vision`/`spec` draft via the configured agent adapter when one
+# is available, and fall back to the static template when none is. Regression test
+# for issue #23 (P1.4 — LLM-driven interview).
+#
+# Drives the REAL compiled CLI over piped (non-TTY) stdin. No real agent/API is
+# used: a stub `.evolve/scripts/agents/claude.sh` adapter stands in for the LLM.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fi; [ "$2" = "$3" ] || fail=$((fail+1)); }
+
+# Install a stub agent adapter that echoes a recognizable document to stdout,
+# proving the LLM path was taken (output replaces the static builder).
+install_stub_adapter() {
+  local dir="$1" body="$2"
+  mkdir -p "$dir/.evolve/scripts/agents"
+  printf '{"agent":"claude"}\n' > "$dir/.evolve/config.json"
+  cat > "$dir/.evolve/scripts/agents/claude.sh" <<EOF
+#!/bin/bash
+run_agent() { cat <<'DOC'
+$body
+DOC
+}
+EOF
+}
+
+# ── Case 1: vision drafts via the agent adapter ──
+T1=$(mktemp -d)
+install_stub_adapter "$T1" "# Vision
+## What We're Building
+AGENT_DRAFTED_VISION_MARKER"
+( cd "$T1"
+  printf '%s\n' \
+    "A command line tool for managing notes" \
+    "Developers who live in the terminal daily" \
+    "They scatter notes across many files today" \
+    "When they cannot find an old note quickly" \
+    "They type a command and see results" \
+    "Fast full text search across all notes" \
+    "Not a heavyweight cloud knowledge base" \
+    "Cut sync and sharing for the first week" \
+    "Daily active use by the author themselves" \
+    "When search returns the right note instantly" \
+    "yes" "yes" | ANTHROPIC_API_KEY=stub-key node "$CLI" vision >/dev/null 2>&1
+) || echo CRASH > "$T1/crash"
+check "vision (agent) does not crash" "$( [ -f "$T1/crash" ] && echo CRASH || echo OK )" "OK"
+check "vision (agent) writes vision.md" "$( [ -f "$T1/.evolve/vision.md" ] && echo YES || echo NO )" "YES"
+check "vision uses agent-drafted output" "$(grep -c 'AGENT_DRAFTED_VISION_MARKER' "$T1/.evolve/vision.md" || true)" "1"
+rm -rf "$T1"
+
+# ── Case 2: vision falls back to the static template with no adapter ──
+T2=$(mktemp -d)
+( cd "$T2"
+  printf '%s\n' \
+    "A command line tool for managing notes" \
+    "Developers who live in the terminal daily" \
+    "They scatter notes across many files today" \
+    "When they cannot find an old note quickly" \
+    "They type a command and see results" \
+    "Fast full text search across all notes" \
+    "Not a heavyweight cloud knowledge base" \
+    "Cut sync and sharing for the first week" \
+    "Daily active use by the author themselves" \
+    "When search returns the right note instantly" \
+    "yes" "yes" | node "$CLI" vision >/dev/null 2>&1
+) || echo CRASH > "$T2/crash"
+check "vision (fallback) does not crash" "$( [ -f "$T2/crash" ] && echo CRASH || echo OK )" "OK"
+check "vision (fallback) writes vision.md" "$( [ -f "$T2/.evolve/vision.md" ] && echo YES || echo NO )" "YES"
+check "vision fallback uses static builder" "$(grep -c 'managing notes' "$T2/.evolve/vision.md" || true)" "1"
+check "vision fallback has no agent marker" "$(grep -c 'AGENT_DRAFTED' "$T2/.evolve/vision.md" || true)" "0"
+rm -rf "$T2"
+
+# ── Case 3: spec drafts via the agent and preserves verbatim feature lines ──
+T3=$(mktemp -d)
+install_stub_adapter "$T3" "# Specification
+## Tech Stack
+SPEC_AGENT_MARKER
+## Features (Priority Order)
+- [ ] Add task command
+- [ ] List all tasks command"
+( cd "$T3"
+  printf '%s\n' \
+    "TypeScript Node.js Commander SQLite Jest" \
+    "A CLI tool using the command pattern" \
+    "Add task command" "List all tasks command" "" \
+    "Tasks stored as markdown files locally" \
+    "CLI subcommands add and list tasks" \
+    "Jest unit tests with coverage target" \
+    "Published to the npm registry package" \
+    "yes" "yes" | ANTHROPIC_API_KEY=stub-key node "$CLI" spec >/dev/null 2>&1
+) || echo CRASH > "$T3/crash"
+check "spec (agent) does not crash" "$( [ -f "$T3/crash" ] && echo CRASH || echo OK )" "OK"
+check "spec uses agent-drafted output" "$(grep -c 'SPEC_AGENT_MARKER' "$T3/.evolve/spec.md" || true)" "1"
+check "spec keeps verbatim feature line" "$(grep -c '^- \[ \] Add task command' "$T3/.evolve/spec.md" || true)" "1"
+rm -rf "$T3"
+
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/tests/test_llm_interview.sh
+++ b/tests/test_llm_interview.sh
@@ -10,13 +10,14 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CLI="$ROOT/dist/cli.js"
 
-[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+# Always rebuild so a stale dist/ can't produce a false pass.
+( cd "$ROOT" && npm run build >/dev/null 2>&1 )
 
 pass=0; fail=0
 check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fi; [ "$2" = "$3" ] || fail=$((fail+1)); }
 
-# Install a stub agent adapter that echoes a recognizable document to stdout,
-# proving the LLM path was taken (output replaces the static builder).
+# Install a stub agent adapter that echoes a fixed document to stdout, proving the
+# LLM path was taken (its output replaces the static builder).
 install_stub_adapter() {
   local dir="$1" body="$2"
   mkdir -p "$dir/.evolve/scripts/agents"
@@ -30,25 +31,28 @@ DOC
 EOF
 }
 
+VISION_ANSWERS=(
+  "A command line tool for managing notes" "Developers who live in the terminal daily"
+  "They scatter notes across many files today" "When they cannot find an old note quickly"
+  "They type a command and see results" "Fast full text search across all notes"
+  "Not a heavyweight cloud knowledge base" "Cut sync and sharing for the first week"
+  "Daily active use by the author themselves" "When search returns the right note instantly"
+  "yes" "yes"
+)
+SPEC_ANSWERS=(
+  "TypeScript Node.js Commander SQLite Jest" "A CLI tool using the command pattern"
+  "Add task command" "List all tasks command" ""
+  "Tasks stored as markdown files locally" "CLI subcommands add and list tasks"
+  "Jest unit tests with coverage target" "Published to the npm registry package"
+  "yes" "yes"
+)
+
 # ── Case 1: vision drafts via the agent adapter ──
 T1=$(mktemp -d)
 install_stub_adapter "$T1" "# Vision
 ## What We're Building
 AGENT_DRAFTED_VISION_MARKER"
-( cd "$T1"
-  printf '%s\n' \
-    "A command line tool for managing notes" \
-    "Developers who live in the terminal daily" \
-    "They scatter notes across many files today" \
-    "When they cannot find an old note quickly" \
-    "They type a command and see results" \
-    "Fast full text search across all notes" \
-    "Not a heavyweight cloud knowledge base" \
-    "Cut sync and sharing for the first week" \
-    "Daily active use by the author themselves" \
-    "When search returns the right note instantly" \
-    "yes" "yes" | ANTHROPIC_API_KEY=stub-key node "$CLI" vision >/dev/null 2>&1
-) || echo CRASH > "$T1/crash"
+( cd "$T1"; printf '%s\n' "${VISION_ANSWERS[@]}" | ANTHROPIC_API_KEY=stub-key node "$CLI" vision >/dev/null 2>&1 ) || echo CRASH > "$T1/crash"
 check "vision (agent) does not crash" "$( [ -f "$T1/crash" ] && echo CRASH || echo OK )" "OK"
 check "vision (agent) writes vision.md" "$( [ -f "$T1/.evolve/vision.md" ] && echo YES || echo NO )" "YES"
 check "vision uses agent-drafted output" "$(grep -c 'AGENT_DRAFTED_VISION_MARKER' "$T1/.evolve/vision.md" || true)" "1"
@@ -56,49 +60,39 @@ rm -rf "$T1"
 
 # ── Case 2: vision falls back to the static template with no adapter ──
 T2=$(mktemp -d)
-( cd "$T2"
-  printf '%s\n' \
-    "A command line tool for managing notes" \
-    "Developers who live in the terminal daily" \
-    "They scatter notes across many files today" \
-    "When they cannot find an old note quickly" \
-    "They type a command and see results" \
-    "Fast full text search across all notes" \
-    "Not a heavyweight cloud knowledge base" \
-    "Cut sync and sharing for the first week" \
-    "Daily active use by the author themselves" \
-    "When search returns the right note instantly" \
-    "yes" "yes" | node "$CLI" vision >/dev/null 2>&1
-) || echo CRASH > "$T2/crash"
+( cd "$T2"; printf '%s\n' "${VISION_ANSWERS[@]}" | node "$CLI" vision >/dev/null 2>&1 ) || echo CRASH > "$T2/crash"
 check "vision (fallback) does not crash" "$( [ -f "$T2/crash" ] && echo CRASH || echo OK )" "OK"
-check "vision (fallback) writes vision.md" "$( [ -f "$T2/.evolve/vision.md" ] && echo YES || echo NO )" "YES"
 check "vision fallback uses static builder" "$(grep -c 'managing notes' "$T2/.evolve/vision.md" || true)" "1"
 check "vision fallback has no agent marker" "$(grep -c 'AGENT_DRAFTED' "$T2/.evolve/vision.md" || true)" "0"
 rm -rf "$T2"
 
-# ── Case 3: spec drafts via the agent and preserves verbatim feature lines ──
+# ── Case 3: spec drafts via the agent AND enforces the verbatim feature list ──
+# The stub deliberately DROPS the second feature; enforcement must restore both
+# while keeping the rest of the agent draft (marker + Deployment) intact.
 T3=$(mktemp -d)
 install_stub_adapter "$T3" "# Specification
 ## Tech Stack
 SPEC_AGENT_MARKER
 ## Features (Priority Order)
 - [ ] Add task command
-- [ ] List all tasks command"
-( cd "$T3"
-  printf '%s\n' \
-    "TypeScript Node.js Commander SQLite Jest" \
-    "A CLI tool using the command pattern" \
-    "Add task command" "List all tasks command" "" \
-    "Tasks stored as markdown files locally" \
-    "CLI subcommands add and list tasks" \
-    "Jest unit tests with coverage target" \
-    "Published to the npm registry package" \
-    "yes" "yes" | ANTHROPIC_API_KEY=stub-key node "$CLI" spec >/dev/null 2>&1
-) || echo CRASH > "$T3/crash"
+## Deployment
+ships to npm registry"
+( cd "$T3"; printf '%s\n' "${SPEC_ANSWERS[@]}" | ANTHROPIC_API_KEY=stub-key node "$CLI" spec >/dev/null 2>&1 ) || echo CRASH > "$T3/crash"
 check "spec (agent) does not crash" "$( [ -f "$T3/crash" ] && echo CRASH || echo OK )" "OK"
 check "spec uses agent-drafted output" "$(grep -c 'SPEC_AGENT_MARKER' "$T3/.evolve/spec.md" || true)" "1"
-check "spec keeps verbatim feature line" "$(grep -c '^- \[ \] Add task command' "$T3/.evolve/spec.md" || true)" "1"
+check "spec restores dropped feature" "$(grep -c '^- \[ \] List all tasks command' "$T3/.evolve/spec.md" || true)" "1"
+check "spec keeps first feature" "$(grep -c '^- \[ \] Add task command' "$T3/.evolve/spec.md" || true)" "1"
+check "spec keeps rest of agent draft" "$(grep -c 'ships to npm registry' "$T3/.evolve/spec.md" || true)" "1"
 rm -rf "$T3"
+
+# ── Case 4: spec falls back to static template when adapter exists but key is unset ──
+T4=$(mktemp -d)
+install_stub_adapter "$T4" "SHOULD_NOT_APPEAR"
+( cd "$T4"; env -u ANTHROPIC_API_KEY printf '%s\n' "${SPEC_ANSWERS[@]}" | env -u ANTHROPIC_API_KEY node "$CLI" spec >/dev/null 2>&1 ) || echo CRASH > "$T4/crash"
+check "spec (no key) does not crash" "$( [ -f "$T4/crash" ] && echo CRASH || echo OK )" "OK"
+check "spec fallback uses static builder" "$(grep -c 'TypeScript Node.js Commander' "$T4/.evolve/spec.md" || true)" "1"
+check "spec fallback ignores adapter output" "$(grep -c 'SHOULD_NOT_APPEAR' "$T4/.evolve/spec.md" || true)" "0"
+rm -rf "$T4"
 
 echo "---"
 echo "passed: $pass  failed: $fail"


### PR DESCRIPTION
Closes #23.

## What
The `vision`/`spec` interviews now route the collected answers through the **configured agent adapter** (`.evolve/scripts/agents/<agent>.sh` — the same `run_agent` path `evolve.sh` uses) to draft `.evolve/vision.md` / `.evolve/spec.md`. The user previews the LLM draft and can **accept** it or ask to **refine** it. With no agent (or required API key) configured, it falls back to the existing static template builder — behavior unchanged.

`init` re-invokes these commands as subprocesses, so this is a single point of change covering all entry points.

## Changes
- `src/utils/agent.ts` — `draftWithAgent(prompt)`: sources the configured adapter, runs `run_agent`, returns text or `null` (adapter missing / key unset / failure / timeout → caller falls back). `spawnSync` timeout (300s) guards a hung agent.
- `src/utils/interview.ts` — shared queue-based reader extracted from `spec.ts`. Also **fixes a latent bug**: `vision.ts`'s old readline reader dropped piped (non-TTY) input between questions.
- `src/commands/vision.ts` / `spec.ts` — draft + accept/refine loop, fallback to static builder. Spec drafting keeps the `- [ ] feature` checklist **verbatim** (the build pipeline parses those lines).
- `tests/test_llm_interview.sh` — drives the compiled CLI over piped stdin with a stub adapter to prove the LLM path, plus the no-adapter fallback, for both `vision` and `spec`.
- `README.md` — documents the LLM-drafting behavior + fallback.

## Acceptance (demonstrated)
- ✅ With a configured agent, the interview produces an **LLM-drafted** vision/spec the user can accept or refine.
- ✅ With no agent configured, it falls back to the current static builder.
- ✅ Spec feature checklist preserved verbatim through agent drafting.

## Testing
All bash suites green: `test_llm_interview.sh` (10), `test_spec_command.sh` (8), `test_init_offer.sh` (7), `test_greenfield_guard.sh` (8). `tsc` clean. Cross-family pre-PR review via `codex review` (one P2 — temp-file write moved inside the fallback path — addressed).

## Known limitations
- No jest unit tests added — jest isn't installed yet and `npm test` is currently broken (tracked separately in #33). Verified via the project's bash-test convention instead.
- Drafting is a blocking (`spawnSync`) call during the interactive interview; acceptable since the interview is already waiting on the agent.

https://claude.ai/code/session_016XyForheNz53b78vTfkC7v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided drafting for vision and spec setup, with an accept-or-refine preview flow.
  * Drafts can now be generated by a configured agent, with a fallback to built-in templates when unavailable.
* **Bug Fixes**
  * Improved interview input handling to reduce prompt hangs and support smoother CLI responses.
* **Documentation**
  * Updated getting-started guidance to explain the new draft-and-refine behavior.
* **Chores**
  * Ignored local planning notes in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->