### PR TITLE
feat(init): execution-mode selector (local/ci/both) persisted in config (P1.5, #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,11 @@ code-evolve init                          # on a terminal, prompts for agent + a
 code-evolve init --agent codex            # skip the prompt; use Codex CLI
 code-evolve init --auth-mode oauth        # use Claude subscription (claude login) instead of API key
 code-evolve init --with-ci               # also install GitHub Actions for cloud evolution
+code-evolve init --mode both             # choose where evolution runs: local | ci | both (persisted in config)
 code-evolve init --force                 # upgrade framework files (preserves journal + learnings)
 ```
+
+`--mode` is the unified execution-mode selector (also offered as an interactive prompt on a terminal). `local` installs a local cron job, `ci` installs the GitHub Actions workflows, `both` does both; the choice is persisted in `.evolve/config.json` and shown by `code-evolve status`. `--with-ci` remains as an alias for `--mode ci`. When `local`/`both` is chosen but the agent's API key isn't set yet, the cron job is deferred — set the key and run `code-evolve start`.
 
 ### `vision`
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,10 +10,16 @@ import {
   writeConfig,
   isValidAgent,
   getAgentEnvHint,
+  getAgentEnvKey,
+  getDefaultModel,
   getSupportedAgents,
   resolveAgentSelection,
+  resolveModeSelection,
+  isValidMode,
   AuthMode,
+  ExecutionMode,
 } from '../utils/config';
+import { installLocalSchedule } from './start';
 
 // Files that contain user/agent evolution history — never overwrite
 const PRESERVE_STATE_FILES = ['JOURNAL.md', 'LEARNINGS.md', 'DAY_COUNT', '.birth_date'];
@@ -24,7 +30,8 @@ export const initCommand = new Command('init')
   .option('--force', 'Overwrite existing .evolve/ directory')
   .option('--agent <name>', 'Agent backend to use (claude, codex, opencode, ollama)', 'claude')
   .option('--auth-mode <mode>', 'Auth mode for Claude: api-key or oauth', 'api-key')
-  .action(async (options: { withCi?: boolean; force?: boolean; agent: string; authMode: string }) => {
+  .option('--mode <mode>', 'Execution mode: local, ci, or both')
+  .action(async (options: { withCi?: boolean; force?: boolean; agent: string; authMode: string; mode?: string }) => {
     const evolveDir = getEvolveDir();
     const templatesDir = getTemplatesDir();
 
@@ -33,6 +40,7 @@ export const initCommand = new Command('init')
       process.argv.some((a) => a === flag || a.startsWith(`${flag}=`));
     const agentExplicit = flagPassed('--agent');
     const authModeExplicit = flagPassed('--auth-mode');
+    const modeExplicit = flagPassed('--mode');
     const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
 
     // Resolve agent: explicit flag wins; else existing config on --force; else default.
@@ -61,6 +69,23 @@ export const initCommand = new Command('init')
       }
     }
 
+    // Resolve execution mode: explicit --mode wins; else --with-ci implies 'ci';
+    // else preserve existing config.mode on --force; else undefined (decide later).
+    let mode: ExecutionMode | undefined;
+    if (modeExplicit) {
+      if (options.mode && isValidMode(options.mode)) {
+        mode = options.mode;
+      } else {
+        console.error(`Unknown mode "${options.mode}". Supported: local, ci, both`);
+        process.exit(1);
+      }
+    } else if (options.withCi) {
+      mode = 'ci';
+    } else if (options.force) {
+      const existingMode = (existingConfig as { mode?: unknown }).mode;
+      if (typeof existingMode === 'string' && isValidMode(existingMode)) mode = existingMode;
+    }
+
     // Fail fast before prompting: don't ask agent/auth questions only to abort.
     if (isInitialized() && !options.force) {
       console.error(`.evolve/ already exists. Use --force to overwrite.`);
@@ -72,6 +97,12 @@ export const initCommand = new Command('init')
       const picked = await promptForAgentAndAuth(agent, !authModeExplicit);
       agent = picked.agent;
       if (picked.authMode) authMode = picked.authMode;
+    }
+
+    // Interactive execution-mode picker: on a TTY, when neither --mode nor
+    // --with-ci was passed, ask where evolution should run.
+    if (interactive && !modeExplicit && !options.withCi) {
+      mode = await promptForMode(mode);
     }
 
     if (!isValidAgent(agent)) {
@@ -163,17 +194,22 @@ export const initCommand = new Command('init')
       }
     }
 
+    // Execution mode drives which artifacts install: CI workflows for ci/both,
+    // a local cron job for local/both. --with-ci stays as a back-compat alias.
+    const wantCi = mode === 'ci' || mode === 'both' || Boolean(options.withCi);
+    const wantLocal = mode === 'local' || mode === 'both';
+
     // Install GitHub Actions workflows directly into .github/workflows/ so they actually run.
     // (GitHub only executes workflows located directly in .github/workflows/, not subdirectories.)
     // Renamed to evolve-* so they never clobber a target repo's own ci.yml/evolve.yml.
     // The bundled CI workflow is Claude-only today (installs claude-code, uses
     // ANTHROPIC_API_KEY). Skip the install for other backends rather than schedule a
     // workflow that would run the wrong agent / fail every cycle. Tracked for per-agent CI.
-    if (options.withCi && agent !== 'claude') {
+    if (wantCi && agent !== 'claude') {
       console.warn(
         `  ⚠ Skipping GitHub Actions install: the bundled workflow supports the Claude backend only and would run the wrong agent in CI. Use local execution (code-evolve start) for "${agent}". Per-agent CI is tracked as a follow-up.`
       );
-    } else if (options.withCi) {
+    } else if (wantCi) {
       console.log('Installing GitHub Actions workflows...');
       const workflowDir = projectFile('.github/workflows');
       fs.mkdirSync(workflowDir, { recursive: true });
@@ -198,17 +234,45 @@ export const initCommand = new Command('init')
       }
     }
 
+    // Install the local cron schedule for local/both modes. Native Windows has
+    // no cron, so skip with a pointer to CI. We only install when the agent's
+    // API key is already in the environment (or none is needed); otherwise the
+    // cron .env would be written without it — defer to `code-evolve start` once
+    // the key is set, matching init's "set your key as a next step" model.
+    let localScheduled = false;
+    if (wantLocal) {
+      if (process.platform === 'win32') {
+        console.warn('  ⚠ Local scheduling is not supported on native Windows — use WSL or ci mode.');
+      } else {
+        const envKey = getAgentEnvKey(agent, authMode);
+        if (!envKey || process.env[envKey]) {
+          try {
+            installLocalSchedule({ agent, authMode, model: getDefaultModel(agent), hours: 4, projectDir: process.cwd() });
+            console.log('Local schedule installed: every 4h (.evolve/evolve.log)');
+            localScheduled = true;
+          } catch (err) {
+            console.warn(`  ⚠ Could not install local cron job: ${(err as Error).message}`);
+          }
+        } else {
+          console.warn(`  ⚠ Local schedule not installed yet: ${envKey} is not set. Set it, then run \`code-evolve start\`.`);
+        }
+      }
+    }
+
     // Update .gitignore (appends only if marker not already present)
     updateGitignore();
 
-    // Write agent config
+    // Write agent config (persist execution mode when one was chosen)
     const currentConfig = readConfig();
-    writeConfig({ ...currentConfig, agent, authMode });
+    writeConfig({ ...currentConfig, agent, authMode, ...(mode ? { mode } : {}) });
     if (agent !== 'claude') {
       console.log(`  Agent: ${agent}`);
     }
     if (authMode === 'oauth') {
       console.log(`  Auth: OAuth (claude login)`);
+    }
+    if (mode) {
+      console.log(`  Mode: ${mode}`);
     }
 
     console.log('');
@@ -240,11 +304,15 @@ export const initCommand = new Command('init')
       console.log(`  ${step++}. Edit .evolve/spec.md with your technical specification`);
     }
     console.log(`  ${step++}. ${getAgentEnvHint(agent, authMode)}`);
-    console.log(`  ${step++}. Run: code-evolve run`);
-    if (!options.withCi) {
+    if (localScheduled) {
+      console.log(`  ${step++}. Local evolution runs every 4h. Run now: code-evolve run`);
+    } else {
+      console.log(`  ${step++}. Run: code-evolve run`);
+    }
+    if (!wantCi || !wantLocal) {
       console.log('');
-      console.log('  To add GitHub Actions (auto-evolve every 4h):');
-      console.log('    code-evolve init --with-ci --force');
+      console.log('  To choose where evolution runs (local / ci / both):');
+      console.log('    code-evolve init --mode <local|ci|both> --force');
     }
   });
 
@@ -328,6 +396,29 @@ async function promptForAgentAndAuth(
       return { agent, authMode: a === '2' || a === 'oauth' ? 'oauth' : 'api-key' };
     }
     return { agent };
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Interactively ask where evolution should run. Free-text (local/ci/both/skip)
+ * to avoid colliding with the numbered agent picker's "Select [1-N]" prompt.
+ * Empty / "skip" keeps the current `fallback` (decide later).
+ */
+async function promptForMode(fallback: ExecutionMode | undefined): Promise<ExecutionMode | undefined> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    console.log('Where should evolution run?');
+    console.log('  local — schedule a cron job on this machine');
+    console.log('  ci    — install GitHub Actions workflows');
+    console.log('  both  — local + CI');
+    console.log('  skip  — decide later (default)');
+    const raw = await new Promise<string>((resolve) => {
+      rl.on('close', () => resolve(''));
+      rl.question('Select [local/ci/both/skip] (default skip): ', resolve);
+    });
+    return resolveModeSelection(raw) ?? fallback;
   } finally {
     rl.close();
   }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -3,9 +3,63 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { getEvolveDir, isInitialized, EVOLVE_DIR_NAME } from '../utils/paths';
-import { readConfig, writeConfig, getAgentEnvKey, getAgentEnvHint, isValidAgent, getDefaultModel } from '../utils/config';
+import { readConfig, writeConfig, getAgentEnvKey, getAgentEnvHint, isValidAgent, getDefaultModel, AuthMode } from '../utils/config';
 
 const CRON_MARKER = 'code-evolve';
+
+export interface ScheduleOptions {
+  agent: string;
+  authMode?: AuthMode;
+  model: string;
+  hours: number;
+  projectDir: string;
+}
+
+/**
+ * Install (or replace) the local cron job for this project and persist
+ * schedule.json. Writes .evolve/.env capturing the current API key (if any).
+ * Shared by `code-evolve start` and `code-evolve init --mode local|both`.
+ * Throws if the crontab update fails. Does NOT validate env keys — callers
+ * decide whether a missing key is fatal.
+ */
+export function installLocalSchedule(opts: ScheduleOptions): void {
+  const { agent, authMode, model, hours, projectDir } = opts;
+  const evolveDir = getEvolveDir();
+  const envFile = path.join(evolveDir, '.env');
+  const logFile = path.join(evolveDir, 'evolve.log');
+  const scriptPath = path.join(evolveDir, 'scripts', 'evolve.sh');
+
+  // Write .env file for cron (cron doesn't inherit shell env)
+  writeEnvFile(envFile, model, agent, authMode);
+
+  // Ensure .evolve/.env is gitignored
+  ensureEnvGitignored(projectDir);
+
+  // Remove any existing code-evolve cron entry for this project
+  removeExistingCron(projectDir);
+
+  // Build cron expression
+  const cronSchedule = hours === 1 ? '0 * * * *' : `0 */${hours} * * *`;
+
+  // The cron command: source .env, run evolve.sh, log output
+  const cronCommand = [
+    cronSchedule,
+    `cd "${projectDir}"`,
+    `&& . "${envFile}"`,
+    `&& EVOLVE_DIR="${EVOLVE_DIR_NAME}" PROJECT_DIR="." AGENT="${agent}"`,
+    `bash "${scriptPath}"`,
+    `>> "${logFile}" 2>&1`,
+    `# ${CRON_MARKER}:${projectDir}`,
+  ].join(' ');
+
+  const existing = getCrontab();
+  const updated = existing ? existing + '\n' + cronCommand + '\n' : cronCommand + '\n';
+  setCrontab(updated);
+
+  // Save schedule config for status command
+  const scheduleConfig = { every: hours, model, agent, authMode: authMode || 'api-key', started: new Date().toISOString() };
+  fs.writeFileSync(path.join(evolveDir, 'schedule.json'), JSON.stringify(scheduleConfig, null, 2) + '\n');
+}
 
 export const startCommand = new Command('start')
   .description('Start the evolution engine (sets up a recurring local cron job)')
@@ -52,55 +106,25 @@ export const startCommand = new Command('start')
 
     const model = options.model || getDefaultModel(agent);
 
-    // Persist agent choice
-    writeConfig({ ...config, agent, authMode });
-
     const projectDir = process.cwd();
     const evolveDir = getEvolveDir();
-    const envFile = path.join(evolveDir, '.env');
-    const logFile = path.join(evolveDir, 'evolve.log');
     const scriptPath = path.join(evolveDir, 'scripts', 'evolve.sh');
 
-    // Write .env file for cron (cron doesn't inherit shell env)
-    writeEnvFile(envFile, model, agent, authMode);
-    console.log('Saved environment config to .evolve/.env');
+    // Persist agent choice + mode. `start` always sets up a local schedule, so
+    // the mode is at least 'local' (keep 'both' if CI was also chosen).
+    writeConfig({ ...config, agent, authMode, mode: config.mode === 'both' ? 'both' : 'local' });
 
-    // Ensure .evolve/.env is gitignored
-    ensureEnvGitignored(projectDir);
-
-    // Remove any existing code-evolve cron entry for this project
-    removeExistingCron(projectDir);
-
-    // Build cron expression
-    const cronSchedule = hours === 1 ? '0 * * * *' : `0 */${hours} * * *`;
-
-    // The cron command: source .env, run evolve.sh, log output
-    const cronCommand = [
-      cronSchedule,
-      `cd "${projectDir}"`,
-      `&& . "${envFile}"`,
-      `&& EVOLVE_DIR="${EVOLVE_DIR_NAME}" PROJECT_DIR="." AGENT="${agent}"`,
-      `bash "${scriptPath}"`,
-      `>> "${logFile}" 2>&1`,
-      `# ${CRON_MARKER}:${projectDir}`,
-    ].join(' ');
-
-    // Install cron entry
+    // Install cron entry + write .env + schedule.json
     try {
-      const existing = getCrontab();
-      const updated = existing ? existing + '\n' + cronCommand + '\n' : cronCommand + '\n';
-      setCrontab(updated);
+      installLocalSchedule({ agent, authMode, model, hours, projectDir });
     } catch (err) {
       console.error('Failed to install cron job:', err);
       process.exit(1);
     }
 
+    console.log('Saved environment config to .evolve/.env');
     console.log(`Cron job installed: every ${hours} hour${hours > 1 ? 's' : ''}`);
     console.log(`Logs: .evolve/evolve.log`);
-
-    // Save schedule config for status command
-    const scheduleConfig = { every: hours, model, agent, authMode: authMode || 'api-key', started: new Date().toISOString() };
-    fs.writeFileSync(path.join(evolveDir, 'schedule.json'), JSON.stringify(scheduleConfig, null, 2) + '\n');
 
     if (options.runNow) {
       console.log('');

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import { evolveFile, isInitialized } from '../utils/paths';
 import { output } from '../utils/output';
+import { readConfig } from '../utils/config';
 
 export const statusCommand = new Command('status')
   .description('Show current evolution state')
@@ -70,9 +71,13 @@ export const statusCommand = new Command('status')
       // not scheduled
     }
 
+    // Read execution mode from config
+    const mode = readConfig().mode ?? null;
+
     const data = {
       day: dayCount,
       started: birthDate,
+      mode,
       features: { total, done, partial, remaining: total - done - partial },
       schedule: schedule ? { every: `${schedule.every}h`, model: schedule.model } : null,
       lastEntry,
@@ -91,6 +96,7 @@ export const statusCommand = new Command('status')
       `code-evolve status`,
       `  Day:      ${dayCount}`,
       `  Started:  ${birthDate}`,
+      `  Mode:     ${mode ?? 'not set'}`,
       `  Progress: ${progressLine}`,
       `  Engine:   ${scheduleLine}`,
       lastEntry ? `\n  Last entry:\n  ${lastEntry.split('\n').join('\n  ')}` : '',

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2,15 +2,18 @@ import fs from 'fs';
 import { evolveFile } from './paths';
 
 export type AuthMode = 'api-key' | 'oauth';
+export type ExecutionMode = 'local' | 'ci' | 'both';
 
 export interface EvolveConfig {
   agent: string;
   model?: string;
   authMode?: AuthMode;
+  mode?: ExecutionMode;
 }
 
 const CONFIG_FILE = 'config.json';
 const SUPPORTED_AGENTS = ['claude', 'codex', 'opencode', 'ollama'];
+const EXECUTION_MODES: ExecutionMode[] = ['local', 'ci', 'both'];
 
 export function getConfigPath(): string {
   return evolveFile(CONFIG_FILE);
@@ -37,6 +40,27 @@ export function writeConfig(config: EvolveConfig): void {
 
 export function isValidAgent(agent: string): boolean {
   return SUPPORTED_AGENTS.includes(agent);
+}
+
+export function isValidMode(mode: string): mode is ExecutionMode {
+  return (EXECUTION_MODES as string[]).includes(mode);
+}
+
+export function getExecutionModes(): ExecutionMode[] {
+  return [...EXECUTION_MODES];
+}
+
+/**
+ * Resolve an interactive execution-mode answer. Accepts a 1-based list index
+ * ("2"), a mode name ("ci"), or "skip"/empty (returns undefined — decide later).
+ */
+export function resolveModeSelection(raw: string): ExecutionMode | undefined {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed || trimmed === 'skip' || trimmed === 'none') return undefined;
+  const n = Number(trimmed);
+  if (Number.isInteger(n) && n >= 1 && n <= EXECUTION_MODES.length) return EXECUTION_MODES[n - 1];
+  if (isValidMode(trimmed)) return trimmed;
+  return undefined;
 }
 
 export function getSupportedAgents(): string[] {

--- a/tests/_drive_init_pty.py
+++ b/tests/_drive_init_pty.py
@@ -4,9 +4,9 @@
 Spawns the compiled CLI with a controlling terminal (so init's `isTTY` checks
 are true), then feeds canned answers as each prompt appears. Two modes:
 
-  decline  agent->1, auth->1, interview offer->"no"
-  cancel   agent->1, auth->1, interview offer->"yes", then Ctrl-D to cancel each
-           launched interview (vision, then spec)
+  decline  agent->1, auth->1, mode->skip, interview offer->"no"
+  cancel   agent->1, auth->1, mode->skip, interview offer->"yes", then Ctrl-D to
+           cancel each launched interview (vision, then spec)
 
 All terminal output is echoed to our stdout so the caller can grep it.
 Usage: _drive_init_pty.py <cli.js> <decline|cancel>
@@ -24,6 +24,7 @@ if mode == "cancel":
     steps = [
         ("Select [1-4]", b"1\n"),
         ("Select [1-2]", b"1\n"),
+        ("Where should evolution run", b"skip\n"),
         ("guided interview", b"yes\n"),
         ("Vision Interview", EOF),
         ("Spec Interview", EOF),
@@ -32,12 +33,14 @@ elif mode == "eof":  # press Ctrl-D at the offer prompt instead of answering
     steps = [
         ("Select [1-4]", b"1\n"),
         ("Select [1-2]", b"1\n"),
+        ("Where should evolution run", b"skip\n"),
         ("guided interview", EOF),
     ]
 else:  # decline
     steps = [
         ("Select [1-4]", b"1\n"),
         ("Select [1-2]", b"1\n"),
+        ("Where should evolution run", b"skip\n"),
         ("guided interview", b"no\n"),
     ]
 

--- a/tests/test_execution_mode.sh
+++ b/tests/test_execution_mode.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Test: `code-evolve init --mode <local|ci|both>` persists the execution mode to
+# config.json and `code-evolve status` reports it. Also checks --mode drives the
+# right artifacts (CI workflows for ci/both) and rejects an invalid mode.
+# Regression test for issue #24 (P1.5).
+#
+# Drives the REAL compiled CLI, non-TTY (piped stdin) so no interactive prompt
+# fires. A stub `claude` on PATH satisfies the dependency check. No env key is
+# set, so the local cron job is deferred (not installed) — keeping the test
+# hermetic (it never touches the user's crontab).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+# Stub agent binary so checkDependencies('claude') passes without a real CLI.
+STUB=$(mktemp -d)
+cat > "$STUB/claude" <<'EOF'
+#!/bin/bash
+echo "claude 0.0.0-stub"
+EOF
+chmod +x "$STUB/claude"
+export PATH="$STUB:$PATH"
+# Ensure no API key leaks in from the environment, so local mode defers cron.
+unset ANTHROPIC_API_KEY OPENAI_API_KEY
+
+run_init() {  # $1 = mode
+  local dir; dir=$(mktemp -d)
+  ( cd "$dir" && git init -q && node "$CLI" init --mode "$1" </dev/null >/dev/null 2>&1 )
+  echo "$dir"
+}
+
+# ── ci mode: persisted + workflows installed ──
+D=$(run_init ci)
+check "ci: mode persisted to config" "$(node -e "console.log(require('$D/.evolve/config.json').mode)")" "ci"
+check "ci: status reports mode"      "$(cd "$D" && node "$CLI" status 2>/dev/null | node -e 'process.stdin.on("data",d=>console.log(JSON.parse(d).mode))')" "ci"
+check "ci: evolve workflow installed" "$([ -f "$D/.github/workflows/evolve.yml" ] && echo yes || echo no)" "yes"
+rm -rf "$D"
+
+# ── local mode: persisted; cron deferred (no key) so no workflows ──
+D=$(run_init local)
+check "local: mode persisted"        "$(node -e "console.log(require('$D/.evolve/config.json').mode)")" "local"
+check "local: no CI workflow"        "$([ -f "$D/.github/workflows/evolve.yml" ] && echo yes || echo no)" "no"
+check "local: cron deferred warning has no schedule.json" "$([ -f "$D/.evolve/schedule.json" ] && echo yes || echo no)" "no"
+rm -rf "$D"
+
+# ── both mode: persisted + workflows installed ──
+D=$(run_init both)
+check "both: mode persisted"         "$(node -e "console.log(require('$D/.evolve/config.json').mode)")" "both"
+check "both: evolve workflow installed" "$([ -f "$D/.github/workflows/evolve.yml" ] && echo yes || echo no)" "yes"
+rm -rf "$D"
+
+# ── invalid mode: exits non-zero with a clear message ──
+D=$(mktemp -d)
+OUT=$( cd "$D" && git init -q && node "$CLI" init --mode bogus </dev/null 2>&1 ) && rc=0 || rc=$?
+check "invalid mode exits non-zero"  "$([ "${rc:-0}" -ne 0 ] && echo yes || echo no)" "yes"
+check "invalid mode explains"        "$(echo "$OUT" | grep -c 'Unknown mode')" "1"
+rm -rf "$D"
+
+# ── back-compat: --with-ci still installs workflows and persists mode=ci ──
+D=$(mktemp -d)
+( cd "$D" && git init -q && node "$CLI" init --with-ci </dev/null >/dev/null 2>&1 )
+check "--with-ci installs workflow"  "$([ -f "$D/.github/workflows/evolve.yml" ] && echo yes || echo no)" "yes"
+check "--with-ci persists mode=ci"   "$(node -e "console.log(require('$D/.evolve/config.json').mode)")" "ci"
+rm -rf "$D"
+
+rm -rf "$STUB"
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Implements **#24 (P1.5)** — a single "execution mode" concept (`local` | `ci` | `both`) chosen in one step at `init`, persisted in `config.json`, and reported by `status`.

## Changes
- **`config.ts`**: `ExecutionMode` type + `mode` field on `EvolveConfig`; `isValidMode` / `resolveModeSelection` helpers.
- **`start.ts`**: extracted the cron-install mechanics into an exported `installLocalSchedule()`. `start` reuses it and now persists `mode` (`local`/`both`).
- **`init.ts`**: `--mode <local|ci|both>` flag **and** an interactive prompt ("Where should evolution run?"). Mode drives which artifacts install — CI workflows for `ci`/`both`, local cron for `local`/`both`. `--with-ci` kept as a back-compat alias (`=ci`).
- **`status.ts`**: surfaces `Mode` in human + JSON output.

## Design note
At `init` time the agent's API key is often not set yet (init lists it as a "next step"). For `local`/`both`, the cron job installs immediately when the key is present (or none is needed, e.g. oauth/ollama); otherwise it's **deferred with a clear message** rather than writing a silently-broken cron entry — run `code-evolve start` once the key is set.

## Acceptance — demonstrated
- ✅ Choose local/ci/both in one step (`init --mode X`)
- ✅ Right artifacts install (CI workflows for ci/both; local cron for local/both)
- ✅ Mode persisted to `config.json`
- ✅ Mode shown by `status` (human + JSON)
- ✅ Invalid mode rejected with a clear message; `--with-ci` back-compat preserved

## Tests
- New `tests/test_execution_mode.sh` (12 checks, hermetic — no real crontab side effects).
- Updated `tests/_drive_init_pty.py` to answer the new interactive prompt.
- All existing shell tests pass.

## Known limitations
- The live cron-install path (key present) reuses the exact extracted `start` mechanics; the new test exercises the deferred path to stay hermetic.
- Bundled CI workflow is still Claude-only (pre-existing; tracked separately).

Closes #24

https://claude.ai/code/session_016XyForheNz53b78vTfkC7v