### PR TITLE
feat(init): configurable evolution schedule at install (P1.6, #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,13 @@ code-evolve init --agent codex            # skip the prompt; use Codex CLI
 code-evolve init --auth-mode oauth        # use Claude subscription (claude login) instead of API key
 code-evolve init --with-ci               # also install GitHub Actions for cloud evolution
 code-evolve init --mode both             # choose where evolution runs: local | ci | both (persisted in config)
+code-evolve init --mode ci --every 6     # run every 6 hours (applies to both the CI cron and the local job)
 code-evolve init --force                 # upgrade framework files (preserves journal + learnings)
 ```
 
 `--mode` is the unified execution-mode selector (also offered as an interactive prompt on a terminal). `local` installs a local cron job, `ci` installs the GitHub Actions workflows, `both` does both; the choice is persisted in `.evolve/config.json` and shown by `code-evolve status`. `--with-ci` remains as an alias for `--mode ci`. When `local`/`both` is chosen but the agent's API key isn't set yet, the cron job is deferred — set the key and run `code-evolve start`.
+
+`--every <hours>` (1–24, default 4) sets the evolution cadence and is applied to **both** targets: the installed GitHub Actions `cron:` and the local cron entry. On a terminal it's also offered as a prompt when a schedule is being installed.
 
 ### `vision`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -45,7 +45,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 - `init` never offers to generate artifacts; the `vision` interview is disconnected and undocumented. → **P1.3**
 - The interview is **hardcoded string Q&A, not the LLM interviewing the user**. → **P1.4**
 - No **execution-mode selector** (local / CI / both); `--with-ci` and `start` are disjoint, no persisted mode. → **P1.5**
-- **Schedule is not configurable at install**: local is `--every <hours>` only; CI cron is hardcoded `0 */4 * * *` in the template. → **P1.6**
+- ~~**Schedule is not configurable at install**: local is `--every <hours>` only; CI cron is hardcoded `0 */4 * * *` in the template.~~ **RESOLVED in #44** — `code-evolve init --every <hours>` now applies the chosen cadence to both the templated CI `cron:` and the local cron entry (prompted on a TTY). → **P1.6 done**
 - No **unified setup wizard** chaining picker → interview → mode → schedule. → **P1.7**
 
 ### 3. Breadth & correctness (works on more repos, correctly)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -19,7 +19,10 @@ import {
   AuthMode,
   ExecutionMode,
 } from '../utils/config';
-import { installLocalSchedule } from './start';
+import { installLocalSchedule, hourlyCron, parseInterval } from './start';
+
+// Default evolution cadence (hours) when --every isn't passed and isn't chosen interactively.
+const DEFAULT_EVERY_HOURS = 4;
 
 // Files that contain user/agent evolution history — never overwrite
 const PRESERVE_STATE_FILES = ['JOURNAL.md', 'LEARNINGS.md', 'DAY_COUNT', '.birth_date'];
@@ -31,7 +34,8 @@ export const initCommand = new Command('init')
   .option('--agent <name>', 'Agent backend to use (claude, codex, opencode, ollama)', 'claude')
   .option('--auth-mode <mode>', 'Auth mode for Claude: api-key or oauth', 'api-key')
   .option('--mode <mode>', 'Execution mode: local, ci, or both')
-  .action(async (options: { withCi?: boolean; force?: boolean; agent: string; authMode: string; mode?: string }) => {
+  .option('--every <hours>', 'Evolution cadence in hours (1–24)')
+  .action(async (options: { withCi?: boolean; force?: boolean; agent: string; authMode: string; mode?: string; every?: string }) => {
     const evolveDir = getEvolveDir();
     const templatesDir = getTemplatesDir();
 
@@ -41,7 +45,19 @@ export const initCommand = new Command('init')
     const agentExplicit = flagPassed('--agent');
     const authModeExplicit = flagPassed('--auth-mode');
     const modeExplicit = flagPassed('--mode');
+    const everyExplicit = flagPassed('--every');
     const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+    // Resolve the evolution cadence: explicit --every wins (validated); else default.
+    let hours = DEFAULT_EVERY_HOURS;
+    if (everyExplicit) {
+      const parsed = parseInterval(options.every ?? '');
+      if (parsed === null) {
+        console.error('--every must be an integer between 1 and 24 hours.');
+        process.exit(2);
+      }
+      hours = parsed;
+    }
 
     // Resolve agent: explicit flag wins; else existing config on --force; else default.
     const existingConfig = options.force ? readConfig() : { agent: 'claude' };
@@ -199,6 +215,12 @@ export const initCommand = new Command('init')
     const wantCi = mode === 'ci' || mode === 'both' || Boolean(options.withCi);
     const wantLocal = mode === 'local' || mode === 'both';
 
+    // Ask for the cadence interactively only when a schedule will actually be
+    // installed and the user didn't already pin it with --every.
+    if (interactive && !everyExplicit && (wantCi || wantLocal)) {
+      hours = await promptForInterval(hours);
+    }
+
     // Install GitHub Actions workflows directly into .github/workflows/ so they actually run.
     // (GitHub only executes workflows located directly in .github/workflows/, not subdirectories.)
     // Renamed to evolve-* so they never clobber a target repo's own ci.yml/evolve.yml.
@@ -228,7 +250,16 @@ export const initCommand = new Command('init')
             `  ⚠ ${path.relative(process.cwd(), destPath)} already exists — skipping; code-evolve's ${destName} was NOT installed (rename or remove the existing file to install it)`
           );
         } else {
-          fs.copyFileSync(srcPath, destPath);
+          // Template the cadence into the evolve workflow's schedule before writing,
+          // so --every reaches CI too (the other workflow has no cron to template).
+          if (src === 'evolve.yml') {
+            const templated = fs
+              .readFileSync(srcPath, 'utf8')
+              .replace(/-\s*cron:\s*'[^']*'[^\n]*/, `- cron: '${hourlyCron(hours)}'  # every ${hours}h`);
+            fs.writeFileSync(destPath, templated);
+          } else {
+            fs.copyFileSync(srcPath, destPath);
+          }
           console.log(`  Created ${path.relative(process.cwd(), destPath)}`);
         }
       }
@@ -247,8 +278,8 @@ export const initCommand = new Command('init')
         const envKey = getAgentEnvKey(agent, authMode);
         if (!envKey || process.env[envKey]) {
           try {
-            installLocalSchedule({ agent, authMode, model: getDefaultModel(agent), hours: 4, projectDir: process.cwd() });
-            console.log('Local schedule installed: every 4h (.evolve/evolve.log)');
+            installLocalSchedule({ agent, authMode, model: getDefaultModel(agent), hours, projectDir: process.cwd() });
+            console.log(`Local schedule installed: every ${hours}h (.evolve/evolve.log)`);
             localScheduled = true;
           } catch (err) {
             console.warn(`  ⚠ Could not install local cron job: ${(err as Error).message}`);
@@ -305,7 +336,7 @@ export const initCommand = new Command('init')
     }
     console.log(`  ${step++}. ${getAgentEnvHint(agent, authMode)}`);
     if (localScheduled) {
-      console.log(`  ${step++}. Local evolution runs every 4h. Run now: code-evolve run`);
+      console.log(`  ${step++}. Local evolution runs every ${hours}h. Run now: code-evolve run`);
     } else {
       console.log(`  ${step++}. Run: code-evolve run`);
     }
@@ -419,6 +450,29 @@ async function promptForMode(fallback: ExecutionMode | undefined): Promise<Execu
       rl.question('Select [local/ci/both/skip] (default skip): ', resolve);
     });
     return resolveModeSelection(raw) ?? fallback;
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Ask how often evolution should run (hours). Empty/invalid input keeps the
+ * current `fallback`. Free-text to match the other init prompts' style.
+ */
+async function promptForInterval(fallback: number): Promise<number> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const raw = await new Promise<string>((resolve) => {
+      rl.on('close', () => resolve(''));
+      rl.question(`How often should evolution run, in hours? [1-24] (default ${fallback}): `, resolve);
+    });
+    if (!raw.trim()) return fallback;
+    const parsed = parseInterval(raw);
+    if (parsed === null) {
+      console.log(`  Invalid interval — using ${fallback}h.`);
+      return fallback;
+    }
+    return parsed;
   } finally {
     rl.close();
   }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -7,6 +7,20 @@ import { readConfig, writeConfig, getAgentEnvKey, getAgentEnvHint, isValidAgent,
 
 const CRON_MARKER = 'code-evolve';
 
+/** Build the "every N hours" cron expression (top of the hour). */
+export function hourlyCron(hours: number): string {
+  return hours === 1 ? '0 * * * *' : `0 */${hours} * * *`;
+}
+
+/** Parse/validate an `--every` hours value. Returns null unless it's a whole
+ *  number in 1–24 — a bare integer string only, so "1.5"/"6abc" are rejected
+ *  rather than silently truncated by parseInt. */
+export function parseInterval(raw: string): number | null {
+  if (!/^\d+$/.test(raw.trim())) return null;
+  const h = parseInt(raw, 10);
+  return h >= 1 && h <= 24 ? h : null;
+}
+
 export interface ScheduleOptions {
   agent: string;
   authMode?: AuthMode;
@@ -39,7 +53,7 @@ export function installLocalSchedule(opts: ScheduleOptions): void {
   removeExistingCron(projectDir);
 
   // Build cron expression
-  const cronSchedule = hours === 1 ? '0 * * * *' : `0 */${hours} * * *`;
+  const cronSchedule = hourlyCron(hours);
 
   // The cron command: source .env, run evolve.sh, log output
   const cronCommand = [
@@ -80,9 +94,9 @@ export const startCommand = new Command('start')
     }
 
     // Validate interval
-    const hours = parseInt(options.every, 10);
-    if (isNaN(hours) || hours < 1 || hours > 24) {
-      console.error('--every must be between 1 and 24 hours.');
+    const hours = parseInterval(options.every);
+    if (hours === null) {
+      console.error('--every must be an integer between 1 and 24 hours.');
       process.exit(2);
     }
 

--- a/tests/test_schedule.sh
+++ b/tests/test_schedule.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Test: `code-evolve init --every <hours>` applies the chosen cadence to BOTH
+# the installed CI workflow (templated cron) and the local cron entry
+# (schedule.json). Also checks an invalid interval is rejected.
+# Regression test for issue #25 (P1.6).
+#
+# Drives the REAL compiled CLI, non-TTY (piped stdin) so no prompt fires. Stubs
+# `claude` (satisfies the dependency check) and `crontab` (so the local install
+# never touches the user's real crontab — keeping the test hermetic).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+STUB=$(mktemp -d)
+cat > "$STUB/claude" <<'EOF'
+#!/bin/bash
+echo "claude 0.0.0-stub"
+EOF
+# No-op crontab stub: `crontab -l` prints nothing (treated as empty), `crontab -`
+# swallows stdin. Never mutates the real user crontab.
+cat > "$STUB/crontab" <<'EOF'
+#!/bin/bash
+cat >/dev/null 2>&1 || true
+exit 0
+EOF
+chmod +x "$STUB/claude" "$STUB/crontab"
+export PATH="$STUB:$PATH"
+
+# ── CI: --every templates the cron line in the installed evolve.yml ──
+unset ANTHROPIC_API_KEY OPENAI_API_KEY
+D=$(mktemp -d)
+( cd "$D" && git init -q && node "$CLI" init --mode ci --every 6 </dev/null >/dev/null 2>&1 )
+check "ci: cron templated to every 6h" "$(grep -c "cron: '0 \*/6 \* \* \*'" "$D/.github/workflows/evolve.yml")" "1"
+check "ci: default 4h cron gone"        "$(grep -c "0 \*/4 \* \* \*" "$D/.github/workflows/evolve.yml")" "0"
+rm -rf "$D"
+
+D=$(mktemp -d)
+( cd "$D" && git init -q && node "$CLI" init --mode ci --every 1 </dev/null >/dev/null 2>&1 )
+check "ci: hourly cron for --every 1"   "$(grep -c "cron: '0 \* \* \* \*'" "$D/.github/workflows/evolve.yml")" "1"
+rm -rf "$D"
+
+# ── Local: --every reaches the cron entry (schedule.json every == chosen) ──
+export ANTHROPIC_API_KEY="sk-test-stub"
+D=$(mktemp -d)
+( cd "$D" && git init -q && node "$CLI" init --mode local --every 6 </dev/null >/dev/null 2>&1 )
+check "local: schedule.json every=6"    "$(node -e "console.log(require('$D/.evolve/schedule.json').every)")" "6"
+rm -rf "$D"
+unset ANTHROPIC_API_KEY
+
+# ── Invalid intervals are rejected (out-of-range and non-integer) ──
+for bad in 0 25 1.5 6abc; do
+  D=$(mktemp -d)
+  OUT=$( cd "$D" && git init -q && node "$CLI" init --mode ci --every "$bad" </dev/null 2>&1 ) && rc=0 || rc=$?
+  check "invalid --every '$bad' exits non-zero" "$([ "${rc:-0}" -ne 0 ] && echo yes || echo no)" "yes"
+  rm -rf "$D"
+done
+
+rm -rf "$STUB"
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #25.

## What

Makes the evolution cadence selectable at install time and applies it to **both** scheduling targets.

- `code-evolve init --every <hours>` (1–24). On a TTY, the interval is also prompted for when a schedule will actually be installed (local/ci/both).
- **CI:** the `cron:` line in `evolve.yml` is templated to the chosen cadence before the workflow is installed (previously hardcoded `0 */4 * * *`).
- **Local:** the chosen interval is passed through to `installLocalSchedule` (previously hardcoded `hours: 4`).

## How

- Extracted shared `hourlyCron()` / `parseInterval()` helpers in `start.ts`, reused by `init`.
- `parseInterval` now rejects non-integer strings (`"1.5"`, `"6abc"`) instead of silently truncating via `parseInt` — this also fixes the same latent bug in `start --every` (flagged by cross-family review).
- CI templating only touches `evolve.yml` (the only workflow with a cron); `--with-ci` back-compat preserved.

## Scope note (deliberate)

The optional raw `--cron <expr>` from the issue is **not** included — the acceptance criterion only requires the chosen *interval* on both targets, which `--every` satisfies. Easy to add later if a real sub-hour need appears.

## Tests

New hermetic `tests/test_schedule.sh` (stubs `claude` + `crontab`, never touches the real crontab):
- `--every 6 --mode ci` → installed workflow has `cron: '0 */6 * * *'`; default 4h cron gone.
- `--every 1 --mode ci` → hourly `cron: '0 * * * *'`.
- `--every 6 --mode local` → `schedule.json` `every == 6`.
- Invalid `--every` (`0`, `25`, `1.5`, `6abc`) all exit non-zero.

All existing shell suites still pass (`test_execution_mode`, `test_init_offer` (PTY), `test_greenfield_guard`, `test_spec_command`, `test_llm_interview`). `npm run lint` clean.