### PR TITLE
feat(setup): unified guided onboarding wizard (P1.7, #26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ code-evolve/                  # npm package source
 ├── src/                      # CLI source (TypeScript)
 │   ├── cli.ts                # Entrypoint (commander)
 │   ├── commands/
-│   │   ├── init.ts           # code-evolve init
+│   │   ├── init.ts           # code-evolve init (exports runInit)
+│   │   ├── setup.ts          # code-evolve setup (guided wizard → runInit)
 │   │   ├── run.ts            # code-evolve run
 │   │   ├── status.ts         # code-evolve status
 │   │   └── eject.ts          # code-evolve eject

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ All commands are available as both `code-evolve <cmd>` and `ce <cmd>`.
 
 | Command | What it does |
 |---------|-------------|
+| `code-evolve setup` | Guided wizard: agent → interview → mode → schedule → ready (re-runnable) |
 | `code-evolve init` | Scaffold `.evolve/` with vision and spec templates |
 | `code-evolve vision` | Guided Socratic interview to generate `.evolve/vision.md` |
 | `code-evolve spec` | Guided interview to generate `.evolve/spec.md` |
@@ -166,6 +167,19 @@ All commands are available as both `code-evolve <cmd>` and `ce <cmd>`.
 | `code-evolve run` | Run one cycle manually |
 | `code-evolve status` | Check progress — day count, features done, schedule |
 | `code-evolve eject` | Remove the framework, keep everything the agent built |
+
+### `setup`
+
+The one-command front door for new projects. On a terminal it chains the whole
+onboarding flow — agent + auth picker, vision + spec interview, execution mode
+(local/ci/both), and schedule — then installs everything and tells you you're
+live. Re-run it any time to reconfigure; it honors your existing config and
+preserves evolution history.
+
+```bash
+code-evolve setup            # guided: nothing → fully configured, ready to evolve
+code-evolve setup --agent codex --mode ci --every 6   # same flags as init, non-interactive
+```
 
 ### `init`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import path from 'path';
 import { Command } from 'commander';
 import { initCommand } from './commands/init';
+import { setupCommand } from './commands/setup';
 import { startCommand } from './commands/start';
 import { stopCommand } from './commands/stop';
 import { runCommand } from './commands/run';
@@ -22,6 +23,7 @@ program
   .version('0.1.0');
 
 program.addCommand(initCommand);
+program.addCommand(setupCommand);
 program.addCommand(startCommand);
 program.addCommand(stopCommand);
 program.addCommand(runCommand);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,6 +27,15 @@ const DEFAULT_EVERY_HOURS = 4;
 // Files that contain user/agent evolution history — never overwrite
 const PRESERVE_STATE_FILES = ['JOURNAL.md', 'LEARNINGS.md', 'DAY_COUNT', '.birth_date'];
 
+export interface InitOptions {
+  withCi?: boolean;
+  force?: boolean;
+  agent: string;
+  authMode: string;
+  mode?: string;
+  every?: string;
+}
+
 export const initCommand = new Command('init')
   .description('Initialize .evolve/ in the current project')
   .option('--with-ci', 'Install GitHub Actions workflows')
@@ -35,7 +44,14 @@ export const initCommand = new Command('init')
   .option('--auth-mode <mode>', 'Auth mode for Claude: api-key or oauth', 'api-key')
   .option('--mode <mode>', 'Execution mode: local, ci, or both')
   .option('--every <hours>', 'Evolution cadence in hours (1–24)')
-  .action(async (options: { withCi?: boolean; force?: boolean; agent: string; authMode: string; mode?: string; every?: string }) => {
+  .action(runInit);
+
+/**
+ * Run the init flow: create `.evolve/`, pick agent/auth/mode/schedule (interactive
+ * on a TTY), copy templates, install CI/cron, optionally run the vision+spec
+ * interviews, and print next steps. Exported so the `setup` wizard reuses it.
+ */
+export async function runInit(options: InitOptions): Promise<void> {
     const evolveDir = getEvolveDir();
     const templatesDir = getTemplatesDir();
 
@@ -345,7 +361,7 @@ export const initCommand = new Command('init')
       console.log('  To choose where evolution runs (local / ci / both):');
       console.log('    code-evolve init --mode <local|ci|both> --force');
     }
-  });
+}
 
 /** Ask a yes/no question on the current TTY. Defaults to no on empty/EOF. */
 async function promptYesNo(question: string): Promise<boolean> {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,0 +1,27 @@
+import { Command } from 'commander';
+import { isInitialized } from '../utils/paths';
+import { runInit, InitOptions } from './init';
+
+/**
+ * `code-evolve setup` — the guided front door to onboarding. It runs the same
+ * flow as `init` (agent/auth picker → execution mode → schedule → vision+spec
+ * interview → summary), but is **re-runnable**: on an already-initialized repo
+ * it auto-enables --force so a second run reconfigures instead of erroring.
+ * init preserves history/state files on --force, so re-running is safe (#26).
+ */
+export const setupCommand = new Command('setup')
+  .description('Guided onboarding wizard: agent → interview → mode → schedule → ready')
+  .option('--with-ci', 'Install GitHub Actions workflows')
+  .option('--force', 'Reconfigure even if .evolve/ already exists')
+  .option('--agent <name>', 'Agent backend to use (claude, codex, opencode, ollama)', 'claude')
+  .option('--auth-mode <mode>', 'Auth mode for Claude: api-key or oauth', 'api-key')
+  .option('--mode <mode>', 'Execution mode: local, ci, or both')
+  .option('--every <hours>', 'Evolution cadence in hours (1–24)')
+  .action(async (options: InitOptions) => {
+    console.log('🌱 code-evolve setup — one guided flow from nothing to a ready-to-evolve repo.\n');
+    // Re-runnable: a second setup on an existing repo reconfigures rather than
+    // aborting. init preserves JOURNAL/LEARNINGS/etc. under --force.
+    if (isInitialized()) options.force = true;
+    await runInit(options);
+    console.log("\n✅ You're live — code-evolve is configured and ready.");
+  });

--- a/tests/test_setup.sh
+++ b/tests/test_setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Test: `code-evolve setup` is the guided onboarding front door to `init`, and is
+# re-runnable — a second `setup` on an already-initialized repo reconfigures
+# (auto --force) instead of erroring, and preserves evolution history/state.
+# Regression test for issue #26 (P1.7 — unified setup wizard).
+#
+# Drives the REAL compiled CLI on piped (non-TTY) stdin, so no interactive
+# pickers fire. A stub `claude` on PATH satisfies the dependency check.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+# Stub agent binary so checkDependencies('claude') passes without a real CLI.
+STUB=$(mktemp -d)
+cat > "$STUB/claude" <<'EOF'
+#!/bin/bash
+echo "claude 0.0.0-stub"
+EOF
+chmod +x "$STUB/claude"
+export PATH="$STUB:$PATH"
+
+# ── Case 1: setup on a fresh repo configures it (creates .evolve/) ──
+T1=$(mktemp -d)
+( cd "$T1" && git init -q )
+OUT1=$( cd "$T1" && node "$CLI" setup </dev/null 2>&1 ) || true
+check "setup prints the wizard banner"      "$(echo "$OUT1" | grep -c 'code-evolve setup' || true)" "1"
+check "setup creates .evolve/"              "$( [ -d "$T1/.evolve" ] && echo yes || echo no )" "yes"
+check "setup prints the you're-live outro"  "$(echo "$OUT1" | grep -c "You're live" || true)" "1"
+check "setup ran the init flow"             "$(echo "$OUT1" | grep -c 'code-evolve initialized' || true)" "1"
+
+# ── Case 2: re-running setup does NOT error and preserves state ──
+# Seed a marker in JOURNAL.md; a re-run must keep it (init preserves state on --force).
+echo "DAY 1: hello" >> "$T1/.evolve/JOURNAL.md"
+OUT2=$( cd "$T1" && node "$CLI" setup </dev/null 2>&1 ); RC=$?
+check "re-run setup exits 0 (re-runnable)"  "$RC" "0"
+check "re-run does not hit greenfield guard" "$(echo "$OUT2" | grep -c 'already exists. Use --force' || true)" "0"
+check "re-run preserves JOURNAL history"     "$(grep -c 'DAY 1: hello' "$T1/.evolve/JOURNAL.md" || true)" "1"
+rm -rf "$T1"
+
+rm -rf "$STUB"
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
Adds `code-evolve setup` (P1.7, #26) — the capstone onboarding command that takes a brand-new repo from nothing to a fully configured, ready-to-evolve setup in **one guided flow**.

On a TTY it chains, in order: agent + auth picker → execution mode (local/ci/both) → schedule cadence → vision + spec interview → install + a "you're live" summary. The pieces already existed inside `init`; this surfaces them as a single discoverable, **re-runnable** command.

## How it works
- Extracts `init`'s action closure into an exported `runInit(options)`; `setup` reuses it verbatim (no logic duplication).
- `setup` is re-runnable: on an already-initialized repo it auto-enables `--force`, which `init` already handles by **preserving** `JOURNAL.md` / `LEARNINGS.md` / `DAY_COUNT` / `.birth_date`. So a second run reconfigures instead of erroring, and honors existing config via the interactive pickers' defaults.
- Same flags as `init` (`--agent`, `--auth-mode`, `--mode`, `--every`, `--with-ci`, `--force`) for non-interactive use.

## Testing
- `tests/test_setup.sh` (new, 7 assertions): fresh repo → `.evolve/` created, init flow ran, "you're live" printed; re-run exits 0, skips the greenfield guard, and preserves seeded `JOURNAL.md` history.
- All existing suites green (init-offer, execution-mode, greenfield-guard, schedule — 35 assertions total).
- `tsc --noEmit` clean.
- **Demo** (interactive PTY): fresh git repo → picked claude/api-key → mode=ci → schedule=6h → declined interview. Result: `config.json` `{agent, authMode:api-key, mode:ci}`, both workflows installed, `evolve.yml` cron templated to `0 */6 * * *`, "✅ You're live".

## Acceptance — met
> One command takes a brand-new repo from nothing to a fully configured, ready-to-run (or scheduled) evolve setup.

## Known limitations
- Step ordering follows `init` (agent → mode → install → interview) rather than the issue's exact listed order; functionally equivalent for the acceptance criterion.

Closes #26
