### PR TITLE
feat(ci): provision stack toolchains (Rust/Go/JVM) (P2.1, #27)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,7 +49,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 - No **unified setup wizard** chaining picker → interview → mode → schedule. → **P1.7**
 
 ### 3. Breadth & correctness (works on more repos, correctly)
-- CI provisions only Node/Python toolchains — **Rust/Go/JVM builds fail in CI**. → **P2.1**
+- ~~CI provisions only Node/Python toolchains — **Rust/Go/JVM builds fail in CI**.~~ **RESOLVED in #46** — both `ci.yml` and `evolve.yml` now detect the stack(s) up front and conditionally install Rust (`dtolnay/rust-toolchain`), Go (`actions/setup-go`), and Java/Kotlin (`actions/setup-java`) toolchains; monorepos install each needed one. Java/Kotlin gating is inert until detection lands (#28). → **P2.1 done**
 - Large class of stacks fall through to "unknown" (no verification): **Java/Kotlin, C#/.NET, Ruby, PHP, C/C++, Deno, static sites**. → **P2.2**
 - `evolve.sh` blindly appends `--quiet` to build/test commands → **false "build has issues" for Go/Make/pip**. → **P2.3**
 - Agent **error detection is Claude-JSON-specific** (`evolve.sh:476`) — codex/ollama/opencode failures pass undetected. → **P2.4**

--- a/templates/workflows/ci.yml
+++ b/templates/workflows/ci.yml
@@ -31,6 +31,38 @@ jobs:
         with:
           version: "latest"
 
+      # Detect the stack(s) up front so toolchain setup actions below can gate on it.
+      # Node/Python/uv are always provisioned above; this covers the compiled stacks.
+      - name: Detect stack toolchains
+        id: detect
+        run: |
+          chmod +x .evolve/scripts/detect_stack.sh
+          STACK_JSON=$(bash .evolve/scripts/detect_stack.sh . 2>/dev/null || echo '{"stack":"unknown"}')
+          # Flatten single-stack + every monorepo substack into one space-padded list.
+          STACKS=$(echo "$STACK_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join([d.get('stack','')] + [s.get('stack','') for s in d.get('substacks',[])]))")
+          echo "Detected stacks: $STACKS"
+          case " $STACKS " in *" rust "*) echo "needs_rust=true" >> "$GITHUB_OUTPUT";; esac
+          case " $STACKS " in *" go "*) echo "needs_go=true" >> "$GITHUB_OUTPUT";; esac
+          # ponytail: java/kotlin not yet emitted by detect_stack.sh (see #28); inert until then.
+          case " $STACKS " in *" java "*|*" kotlin "*) echo "needs_java=true" >> "$GITHUB_OUTPUT";; esac
+
+      - name: Setup Rust
+        if: steps.detect.outputs.needs_rust == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Go
+        if: steps.detect.outputs.needs_go == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Setup Java
+        if: steps.detect.outputs.needs_java == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Detect and verify project
         run: |
           chmod +x .evolve/scripts/detect_stack.sh

--- a/templates/workflows/evolve.yml
+++ b/templates/workflows/evolve.yml
@@ -31,6 +31,36 @@ jobs:
         with:
           python-version: '3.12'
 
+      # evolve.sh builds/tests the project, so its toolchains must be present too.
+      - name: Detect stack toolchains
+        id: detect
+        run: |
+          chmod +x .evolve/scripts/detect_stack.sh
+          STACK_JSON=$(bash .evolve/scripts/detect_stack.sh . 2>/dev/null || echo '{"stack":"unknown"}')
+          STACKS=$(echo "$STACK_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(' '.join([d.get('stack','')] + [s.get('stack','') for s in d.get('substacks',[])]))")
+          echo "Detected stacks: $STACKS"
+          case " $STACKS " in *" rust "*) echo "needs_rust=true" >> "$GITHUB_OUTPUT";; esac
+          case " $STACKS " in *" go "*) echo "needs_go=true" >> "$GITHUB_OUTPUT";; esac
+          # ponytail: java/kotlin not yet emitted by detect_stack.sh (see #28); inert until then.
+          case " $STACKS " in *" java "*|*" kotlin "*) echo "needs_java=true" >> "$GITHUB_OUTPUT";; esac
+
+      - name: Setup Rust
+        if: steps.detect.outputs.needs_rust == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Go
+        if: steps.detect.outputs.needs_go == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Setup Java
+        if: steps.detect.outputs.needs_java == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 


### PR DESCRIPTION
## Summary
Fixes #27. CI provisioned only Node/Python/uv, so Rust, Go, and JVM repos had no toolchain and their build/test verification failed even though `detect_stack.sh` detected them.

Both `templates/workflows/ci.yml` and `templates/workflows/evolve.yml` now:
1. Run a **Detect stack toolchains** step that flattens the single-stack value plus every monorepo substack into one list and emits `needs_rust` / `needs_go` / `needs_java` outputs.
2. Conditionally install the matching toolchain, gated on those outputs:
   - Rust → `dtolnay/rust-toolchain@stable`
   - Go → `actions/setup-go@v5`
   - Java/Kotlin → `actions/setup-java@v4` (temurin 21)

Unrelated repos skip every setup step, so they pay no extra cost.

## Acceptance criteria
- [x] A Rust repo gets `needs_rust=true` → Rust toolchain installed before `cargo build/test`.
- [x] A Go repo gets `needs_go=true` → Go toolchain installed before `go build/test`.
- [x] Monorepos with multiple compiled substacks install each needed toolchain.
- [x] Node/Python/unknown repos install no extra toolchain.

## Verification
Simulated the exact gating logic against sample `detect_stack.sh` JSON (rust, go, python, rust+go+ts monorepo, unknown) — flags match expectations. Both workflows parse as valid YAML. `codex review` found no introduced bugs.

## Known limitations
- Java/Kotlin gating is **inert** until `detect_stack.sh` emits `java`/`kotlin` stacks (tracked in #28). Added now because #27 explicitly requests JVM; it activates automatically once detection lands.
- In `evolve.yml`, stack is detected at job start. On a first run that *creates* a new compiled-stack project from scratch, that run's build verification may lack the toolchain; subsequent runs pick it up. Pre-existing constraint of the detect-then-run design.