### PR TITLE
feat(detect): stack detectors for Deno/JVM/.NET/Ruby/PHP/C++/static (P2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,16 @@ Drop code-evolve into any project. It figures out how to build and test it:
 | Python | `pyproject.toml` | `uv sync` | `uv run pytest` | `uv run ruff check .` |
 | Rust | `Cargo.toml` | `cargo build` | `cargo test` | `cargo clippy` |
 | Go | `go.mod` | `go build ./...` | `go test ./...` | `go vet ./...` |
+| Deno | `deno.json` | — | `deno test` | `deno lint` |
+| Java/Kotlin | `pom.xml` / `build.gradle` | `mvn compile` / `gradle build` | `mvn test` / `gradle test` | — |
+| C#/.NET | `*.csproj` / `*.sln` | `dotnet build` | `dotnet test` | — |
+| Ruby | `Gemfile` | `bundle install` | `rspec` / `rake` | `rubocop` |
+| PHP | `composer.json` | `composer install` | `composer test` / `phpunit` | — |
+| C/C++ | `CMakeLists.txt` | `cmake --build build` | `ctest` | — |
+| Static | `index.html` | — | — | — |
 
-Package managers (npm, yarn, pnpm, bun) and Python tooling (uv, poetry, pip) are detected automatically.
+Package managers (npm, yarn, pnpm, bun), Python tooling (uv, poetry, pip), and
+the Gradle wrapper (`./gradlew`) are detected automatically.
 
 **Monorepos** are supported automatically. If no stack marker is found at the project root, code-evolve scans immediate subdirectories. When multiple stacks are found (e.g., `backend/` with Python and `frontend/` with Next.js), each substack is verified independently — build, test, and lint run in their respective directories. The post-session fix loop and CI workflow both handle monorepos.
 

--- a/templates/scripts/detect_stack.sh
+++ b/templates/scripts/detect_stack.sh
@@ -29,6 +29,14 @@ detect_single_stack() {
         LINT_CMD="cargo clippy --all-targets -- -D warnings"
         FORMAT_CMD="cargo fmt -- --check"
 
+    elif [ -f "$dir/deno.json" ] || [ -f "$dir/deno.jsonc" ]; then
+        # Checked before package.json: Deno projects may ship one for npm compat.
+        STACK="deno"
+        BUILD_CMD=""
+        TEST_CMD="deno test"
+        LINT_CMD="deno lint"
+        FORMAT_CMD="deno fmt --check"
+
     elif [ -f "$dir/package.json" ]; then
         # Detect package manager
         local PKG_MGR="npm"
@@ -105,10 +113,77 @@ detect_single_stack() {
         LINT_CMD="go vet ./..."
         FORMAT_CMD="gofmt -l ."
 
+    elif [ -f "$dir/pom.xml" ]; then
+        STACK="java"
+        BUILD_CMD="mvn compile"
+        TEST_CMD="mvn test"
+        LINT_CMD=""
+        FORMAT_CMD=""
+
+    elif [ -f "$dir/build.gradle" ] || [ -f "$dir/build.gradle.kts" ] || \
+         [ -f "$dir/settings.gradle" ] || [ -f "$dir/settings.gradle.kts" ]; then
+        STACK="java"
+        # Prefer the project's wrapper for a pinned Gradle version.
+        local GRADLE="gradle"
+        [ -f "$dir/gradlew" ] && GRADLE="./gradlew"
+        BUILD_CMD="$GRADLE build"
+        TEST_CMD="$GRADLE test"
+        LINT_CMD=""
+        FORMAT_CMD=""
+
+    elif compgen -G "$dir/*.sln" >/dev/null || compgen -G "$dir/*.csproj" >/dev/null; then
+        STACK="dotnet"
+        BUILD_CMD="dotnet build"
+        TEST_CMD="dotnet test"
+        LINT_CMD=""
+        FORMAT_CMD="dotnet format --verify-no-changes"
+
+    elif [ -f "$dir/Gemfile" ]; then
+        STACK="ruby"
+        BUILD_CMD="bundle install"
+        if grep -q "rspec" "$dir/Gemfile" 2>/dev/null; then
+            TEST_CMD="bundle exec rspec"
+        else
+            TEST_CMD="bundle exec rake"
+        fi
+        if grep -q "rubocop" "$dir/Gemfile" 2>/dev/null; then
+            LINT_CMD="bundle exec rubocop"
+        else
+            LINT_CMD=""
+        fi
+        FORMAT_CMD=""
+
+    elif [ -f "$dir/composer.json" ]; then
+        STACK="php"
+        BUILD_CMD="composer install"
+        if grep -q '"test"' "$dir/composer.json" 2>/dev/null; then
+            TEST_CMD="composer test"
+        else
+            TEST_CMD="vendor/bin/phpunit"
+        fi
+        LINT_CMD=""
+        FORMAT_CMD=""
+
+    elif [ -f "$dir/CMakeLists.txt" ]; then
+        # Checked before Makefile: CMake projects often ship a generated Makefile too.
+        STACK="cpp"
+        BUILD_CMD="cmake -S . -B build && cmake --build build"
+        TEST_CMD="ctest --test-dir build"
+        LINT_CMD=""
+        FORMAT_CMD=""
+
     elif [ -f "$dir/Makefile" ]; then
         STACK="make"
         BUILD_CMD="make"
         TEST_CMD="make test"
+        LINT_CMD=""
+        FORMAT_CMD=""
+
+    elif [ -f "$dir/index.html" ]; then
+        # Weakest signal — last resort before "unknown". Static site: no build/test.
+        STACK="static"
+        BUILD_CMD=""
+        TEST_CMD=""
         LINT_CMD=""
         FORMAT_CMD=""
     fi

--- a/tests/test_detect_stack.sh
+++ b/tests/test_detect_stack.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Test: detect_stack.sh recognizes the stacks added in P2.2 (issue #28) —
+# Java/Kotlin (Maven/Gradle), C#/.NET, Ruby, PHP, C/C++ (CMake), Deno, static —
+# in addition to the pre-existing Rust/JS-TS/Python/Go/Make detectors, and that
+# new stacks also surface through the monorepo substack scan.
+#
+# Drives the real script against temp dirs holding only a marker file. Hermetic:
+# no toolchains required (the script emits commands; it does not run them).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/templates/scripts/detect_stack.sh"
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+# field <json> <key>  → extract a top-level string field
+field() { echo "$1" | python3 -c "import sys,json; print(json.load(sys.stdin).get('$2',''))"; }
+
+# detect <setup-fn>  → run setup in a fresh temp dir, echo the JSON
+detect() {
+  local d; d=$(mktemp -d); ( cd "$d" && "$1" )
+  bash "$SCRIPT" "$d"
+  rm -rf "$d"
+}
+
+# ── Deno ──
+mk_deno() { echo '{}' > deno.json; }
+J=$(detect mk_deno)
+check "deno: stack"  "$(field "$J" stack)"  "deno"
+check "deno: test"   "$(field "$J" test)"   "deno test"
+check "deno: format" "$(field "$J" format)" "deno fmt --check"
+
+# ── Deno wins over a co-located package.json (npm-compat projects) ──
+mk_deno_pkg() { echo '{}' > deno.json; echo '{"scripts":{"build":"x"}}' > package.json; }
+J=$(detect mk_deno_pkg)
+check "deno+pkg: deno wins" "$(field "$J" stack)" "deno"
+
+# ── Java / Maven ──
+mk_maven() { echo '<project/>' > pom.xml; }
+J=$(detect mk_maven)
+check "maven: stack" "$(field "$J" stack)" "java"
+check "maven: build" "$(field "$J" build)" "mvn compile"
+check "maven: test"  "$(field "$J" test)"  "mvn test"
+
+# ── Java / Gradle (with wrapper) ──
+mk_gradle() { echo 'plugins {}' > build.gradle.kts; : > gradlew; }
+J=$(detect mk_gradle)
+check "gradle: stack" "$(field "$J" stack)" "java"
+check "gradle: build" "$(field "$J" build)" "./gradlew build"
+check "gradle: test"  "$(field "$J" test)"  "./gradlew test"
+
+# ── .NET ──
+mk_dotnet() { echo '<Project/>' > App.csproj; }
+J=$(detect mk_dotnet)
+check "dotnet: stack"  "$(field "$J" stack)"  "dotnet"
+check "dotnet: build"  "$(field "$J" build)"  "dotnet build"
+check "dotnet: format" "$(field "$J" format)" "dotnet format --verify-no-changes"
+
+# ── Ruby (rspec + rubocop) ──
+mk_ruby() { printf "gem 'rspec'\ngem 'rubocop'\n" > Gemfile; }
+J=$(detect mk_ruby)
+check "ruby: stack" "$(field "$J" stack)" "ruby"
+check "ruby: test"  "$(field "$J" test)"  "bundle exec rspec"
+check "ruby: lint"  "$(field "$J" lint)"  "bundle exec rubocop"
+
+# ── Ruby (default rake, no rubocop) ──
+mk_ruby2() { echo "source 'https://rubygems.org'" > Gemfile; }
+J=$(detect mk_ruby2)
+check "ruby-rake: test" "$(field "$J" test)" "bundle exec rake"
+check "ruby-rake: lint" "$(field "$J" lint)" ""
+
+# ── PHP (composer test script) ──
+mk_php() { echo '{"scripts":{"test":"phpunit"}}' > composer.json; }
+J=$(detect mk_php)
+check "php: stack" "$(field "$J" stack)" "php"
+check "php: test"  "$(field "$J" test)"  "composer test"
+
+# ── PHP (no test script → phpunit) ──
+mk_php2() { echo '{}' > composer.json; }
+J=$(detect mk_php2)
+check "php-phpunit: test" "$(field "$J" test)" "vendor/bin/phpunit"
+
+# ── C/C++ (CMake) ──
+mk_cpp() { echo 'project(x)' > CMakeLists.txt; }
+J=$(detect mk_cpp)
+check "cpp: stack" "$(field "$J" stack)" "cpp"
+check "cpp: test"  "$(field "$J" test)"  "ctest --test-dir build"
+
+# ── CMake wins over a sibling Makefile ──
+mk_cpp_make() { echo 'project(x)' > CMakeLists.txt; echo 'all:' > Makefile; }
+J=$(detect mk_cpp_make)
+check "cpp+make: cmake wins" "$(field "$J" stack)" "cpp"
+
+# ── Static site (weakest signal, after Makefile) ──
+mk_static() { echo '<html></html>' > index.html; }
+J=$(detect mk_static)
+check "static: stack" "$(field "$J" stack)" "static"
+
+# ── Monorepo: new stacks surface as substacks ──
+MONO=$(mktemp -d)
+mkdir -p "$MONO/api" "$MONO/web"
+echo '<project/>' > "$MONO/api/pom.xml"
+echo '{}' > "$MONO/web/deno.json"
+JM=$(bash "$SCRIPT" "$MONO")
+check "monorepo: stack" "$(field "$JM" stack)" "monorepo"
+check "monorepo: substack stacks" \
+  "$(echo "$JM" | python3 -c "import sys,json; print(','.join(sorted(s['stack'] for s in json.load(sys.stdin)['substacks'])))")" \
+  "deno,java"
+rm -rf "$MONO"
+
+echo "----"
+echo "PASS: $pass  FAIL: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #28.

## What

Extends `detect_single_stack()` in `templates/scripts/detect_stack.sh` so repos that previously fell through to `unknown` (and got **no** build/test/lint verification) now get sensible commands.

| Stack | Marker | Test cmd |
|-------|--------|----------|
| Deno | `deno.json`/`.jsonc` | `deno test` |
| Java/Kotlin | `pom.xml` / `build.gradle{,.kts}` | `mvn test` / `./gradlew test` (wrapper auto-detected) |
| C#/.NET | `*.sln` / `*.csproj` | `dotnet test` |
| Ruby | `Gemfile` | `bundle exec rspec` / `rake` (+ `rubocop` lint if present) |
| PHP | `composer.json` | `composer test` (if script) / `vendor/bin/phpunit` |
| C/C++ | `CMakeLists.txt` | `ctest --test-dir build` |
| Static | `index.html` | — (detection only) |

## Ordering decisions
- **Deno before `package.json`** — Deno npm-compat projects may ship a `package.json`; the `deno.json` marker is more specific (caught by codex review).
- **CMake before `Makefile`** — CMake projects often have a generated `Makefile`.
- **`index.html` last** — weakest signal, only before `unknown`.

Monorepo substack scanning reuses the same function, so all new stacks work there automatically.

## Tests
- `tests/test_detect_stack.sh` — 27 assertions (one temp dir per stack + monorepo + the two ordering tie-breaks). Mirrors the existing `tests/*.sh` convention. All green.
- `npm run lint` / `npm run build` clean; existing TS self-detection unchanged.
- Cross-family review: `codex` (one Major addressed: Deno ordering).

## Known limitations
- Static sites detect with empty build/test commands (there's no universal static toolchain) — the point is a non-`unknown` classification.
- Stack named `java` for both Maven and Gradle/Kotlin (informational label only).