### PR TITLE
fix(evolve): stack-aware build/test/format invocation (P2.3, #29)

### DIFF
--- a/templates/scripts/evolve.sh
+++ b/templates/scripts/evolve.sh
@@ -164,18 +164,18 @@ for s in json.load(sys.stdin):
 " 2>/dev/null | while IFS='|' read -r sdir sbuild stest; do
         SUBPATH="$PROJECT_DIR/$sdir"
         if [ -n "$sbuild" ]; then
-            (cd "$SUBPATH" && eval "$sbuild" --quiet 2>/dev/null) && echo "  $sdir build OK." || echo "  $sdir build has issues (agent will address)."
+            (cd "$SUBPATH" && eval "$sbuild" >/dev/null 2>&1) && echo "  $sdir build OK." || echo "  $sdir build has issues (agent will address)."
         fi
         if [ -n "$stest" ]; then
-            (cd "$SUBPATH" && eval "$stest" --quiet 2>/dev/null) && echo "  $sdir tests OK." || true
+            (cd "$SUBPATH" && eval "$stest" >/dev/null 2>&1) && echo "  $sdir tests OK." || true
         fi
     done
     echo ""
 elif [ -n "$BUILD_CMD" ] && [ "$STACK" != "unknown" ]; then
     echo "-> Checking existing build..."
     cd "$PROJECT_DIR" 2>/dev/null || true
-    eval "$BUILD_CMD" --quiet 2>/dev/null && echo "  Build OK." || echo "  Build has issues (agent will address)."
-    [ -n "$TEST_CMD" ] && eval "$TEST_CMD" --quiet 2>/dev/null && echo "  Tests OK." || true
+    eval "$BUILD_CMD" >/dev/null 2>&1 && echo "  Build OK." || echo "  Build has issues (agent will address)."
+    [ -n "$TEST_CMD" ] && eval "$TEST_CMD" >/dev/null 2>&1 && echo "  Tests OK." || true
     cd - > /dev/null 2>/dev/null || true
     echo ""
 fi
@@ -501,6 +501,17 @@ STACK=$(echo "$STACK_JSON" | python3 -c "import sys,json; print(json.load(sys.st
 BUILD_CMD=$(echo "$STACK_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['build'])" 2>/dev/null || echo "")
 TEST_CMD=$(echo "$STACK_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['test'])" 2>/dev/null || echo "")
 LINT_CMD=$(echo "$STACK_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['lint'])" 2>/dev/null || echo "")
+FORMAT_CMD=$(echo "$STACK_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['format'])" 2>/dev/null || echo "")
+
+# Map a format *check* command to its in-place *fix* equivalent (stack-aware).
+# `gofmt -l` only lists, `dotnet --verify-no-changes` only checks — stripping
+# `--check` alone is a no-op for those. Covers every FORMAT_CMD detect_stack emits.
+format_fix_cmd() {
+    echo "$1" \
+        | sed 's/ -- --check//; s/ --check//' \
+        | sed 's/gofmt -l/gofmt -w/' \
+        | sed 's/ --verify-no-changes//'
+}
 
 # Helper: verify a single substack directory, append errors to ERRORS_FILE
 verify_single_stack() {
@@ -509,7 +520,7 @@ verify_single_stack() {
     # Auto-fix formatting if possible
     if [ -n "$sformat" ]; then
         local sformat_fix
-        sformat_fix=$(echo "$sformat" | sed 's/ --check//')
+        sformat_fix=$(format_fix_cmd "$sformat")
         if ! (cd "$subpath" && eval "$sformat") 2>/dev/null; then
             (cd "$subpath" && eval "$sformat_fix") 2>/dev/null && \
                 git add -A && git commit -m "Day $DAY ($SESSION_TIME): auto-format $label" || true

--- a/tests/test_format_fix.sh
+++ b/tests/test_format_fix.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Test: format_fix_cmd in evolve.sh maps a format *check* command to its
+# in-place *fix* equivalent for every stack detect_stack.sh emits (P2.3, #29).
+# Extracts the real function from the real script — no copy, no toolchains.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+eval "$(sed -n '/^format_fix_cmd()/,/^}/p' "$ROOT/templates/scripts/evolve.sh")"
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+
+# check command → fix command
+check "rust"       "$(format_fix_cmd 'cargo fmt -- --check')"        "cargo fmt"
+check "deno"       "$(format_fix_cmd 'deno fmt --check')"            "deno fmt"
+check "ruff (uv)"  "$(format_fix_cmd 'uv run ruff format --check .')" "uv run ruff format ."
+check "ruff (pip)" "$(format_fix_cmd 'ruff format --check .')"        "ruff format ."
+check "go (-l→-w)" "$(format_fix_cmd 'gofmt -l .')"                   "gofmt -w ."
+check "dotnet"     "$(format_fix_cmd 'dotnet format --verify-no-changes')" "dotnet format"
+
+echo "----"
+echo "PASS: $pass  FAIL: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #29.

## Problem
`evolve.sh` blindly appended `--quiet` to the detected build/test command for the pre-session check, and stripped `--check` to derive the format auto-fix. Both are stack-specific assumptions that break on several stacks:

- `go build ./...`, `dotnet build`, `cmake`, BSD `make` reject `--quiet` → false "build has issues" signals.
- `gofmt -l .` (lists only) and `dotnet format --verify-no-changes` (checks only) are **not** fixed by stripping `--check` — formatting never actually rewrites files.

## Changes
- **Drop the `--quiet` suffix** from the pre-session build/test checks; redirect output with `>/dev/null 2>&1` instead. Stack-agnostic — the check only cares about exit code.
- **Add `format_fix_cmd()`** — a small stack-aware map from check→fix: `gofmt -l`→`gofmt -w`, drop `--check`/`-- --check`, drop `dotnet`'s `--verify-no-changes`. Covers every `FORMAT_CMD` `detect_stack.sh` emits.
- **Re-detect `FORMAT_CMD`** in the post-session verify block (latent bug: it was stale after a greenfield bootstrap, so format auto-fix never ran in the single-stack path).

## Acceptance
- Go and Makefile repos no longer report false build failures (no `--quiet`).
- `gofmt`-based formatting now rewrites files (`-l`→`-w`).

## Tests
New hermetic `tests/test_format_fix.sh` extracts the real `format_fix_cmd` from `evolve.sh` and asserts the mapping across all stacks (rust/deno/ruff/go/dotnet) — 6/6 pass. `tests/test_detect_stack.sh` 27/27, `bash -n` clean.

## Known limitations
The `--quiet` drop trades a tiny bit of log verbosity (output now goes to `/dev/null`) for correctness across stacks; the pre-session check was already discarding stderr and only uses the exit code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and test checks to run quietly without adding extra command flags.
  * Formatting checks can now automatically apply the matching fix command when a formatter is detected.

* **Tests**
  * Added coverage for formatting check-to-fix command mappings across multiple toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->