### PR TITLE
fix(evolve): per-adapter agent error detection (P2.4, #30)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -52,7 +52,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 - ~~CI provisions only Node/Python toolchains — **Rust/Go/JVM builds fail in CI**.~~ **RESOLVED in #46** — both `ci.yml` and `evolve.yml` now detect the stack(s) up front and conditionally install Rust (`dtolnay/rust-toolchain`), Go (`actions/setup-go`), and Java/Kotlin (`actions/setup-java`) toolchains; monorepos install each needed one. Java/Kotlin gating is inert until detection lands (#28). → **P2.1 done**
 - Large class of stacks fall through to "unknown" (no verification): **Java/Kotlin, C#/.NET, Ruby, PHP, C/C++, Deno, static sites**. → **P2.2**
 - `evolve.sh` blindly appends `--quiet` to build/test commands → **false "build has issues" for Go/Make/pip**. → **P2.3**
-- Agent **error detection is Claude-JSON-specific** (`evolve.sh:476`) — codex/ollama/opencode failures pass undetected. → **P2.4**
+- ~~Agent **error detection is Claude-JSON-specific** (`evolve.sh:476`) — codex/ollama/opencode failures pass undetected.~~ **RESOLVED in #49** — the main session now captures `run_agent`'s real exit code (no longer masked by `tee`) and flags a failure on non-zero exit OR a per-adapter `agent_detect_error` marker (Claude keeps its `"type":"error"` grep; other adapters defer to exit code). → **P2.4 done**
 - codex/opencode/ollama adapter invocations are **unverified against the real CLIs** (e.g. Codex now uses `codex exec`). → **P2.5**
 - Skills are greenfield/spec-driven; **no instruction to discover & honor an existing mature repo's conventions**. → **P2.6**
 
@@ -79,7 +79,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 | P2.1 | [#27](https://github.com/frankbria/code-evolve/issues/27) | Medium | Provision CI toolchains for the detected stack (Rust/Go/JVM) | — |
 | P2.2 | [#28](https://github.com/frankbria/code-evolve/issues/28) | Medium | Add stack detectors for Java/Kotlin, C#/.NET, Ruby, PHP, C/C++, Deno, static | — |
 | P2.3 | [#29](https://github.com/frankbria/code-evolve/issues/29) | Medium | Make build/test/format invocation stack-aware (drop blind `--quiet`) | — |
-| P2.4 | [#30](https://github.com/frankbria/code-evolve/issues/30) | Medium | Per-adapter agent error detection (stop assuming Claude JSON) | — |
+| P2.4 | [#30](https://github.com/frankbria/code-evolve/issues/30) ✅ | Medium | Per-adapter agent error detection (stop assuming Claude JSON) *(done in #49)* | — |
 | P2.5 | [#31](https://github.com/frankbria/code-evolve/issues/31) | Medium | Verify & fix codex/opencode/ollama adapter invocations vs real CLIs | — |
 | P2.6 | [#32](https://github.com/frankbria/code-evolve/issues/32) | Medium | Add a "respect existing repo conventions" pass for mature repos | — |
 | P3.1 | [#33](https://github.com/frankbria/code-evolve/issues/33) | Low | Add jest + first unit tests; fix the broken `npm test` | — |

--- a/templates/scripts/agents/claude.sh
+++ b/templates/scripts/agents/claude.sh
@@ -28,6 +28,12 @@ run_agent() {
         < "$prompt_file" 2>&1
 }
 
+# agent_detect_error <logfile> — returns 0 if the log shows a Claude API error.
+# Claude's stream-JSON emits {"type":"error",...} even on exit 0, so grep for it.
+agent_detect_error() {
+    grep -q '"type":"error"' "$1" 2>/dev/null
+}
+
 agent_env_hint() {
     if [ "$CLAUDE_AUTH_MODE" = "oauth" ]; then
         echo "Run 'claude login' to authenticate via OAuth"

--- a/templates/scripts/evolve.sh
+++ b/templates/scripts/evolve.sh
@@ -51,6 +51,13 @@ if ! check_agent; then
     exit 1
 fi
 
+# Fallback for adapters that don't ship a log-based error detector (codex/opencode/
+# ollama emit plain text, so there's no reliable marker — rely on the process exit
+# code instead). Only Claude's stream-JSON warrants a grep, defined in claude.sh.
+if ! declare -f agent_detect_error >/dev/null; then
+    agent_detect_error() { return 1; }
+fi
+
 # Read birth date from file if it exists, otherwise set it
 if [ -f "$EVOLVE_DIR/.birth_date" ]; then
     BIRTH_DATE=$(cat "$EVOLVE_DIR/.birth_date")
@@ -478,14 +485,18 @@ Read $EVOLVE_DIR/IDENTITY.md first. Now begin.
 PROMPT
 
 AGENT_LOG=$(mktemp)
-# Run agent via adapter
-run_agent "$PROMPT_FILE" "$MODEL" "$TIMEOUT_CMD" "$TIMEOUT" 2>&1 | tee "$AGENT_LOG" || true
+# Run agent via adapter. Capture its real exit code — `tee` would otherwise mask it
+# (pipefail makes PIPESTATUS[0] reachable, but `|| true` would reset it).
+AGENT_RC=0
+run_agent "$PROMPT_FILE" "$MODEL" "$TIMEOUT_CMD" "$TIMEOUT" 2>&1 | tee "$AGENT_LOG" || AGENT_RC=$?
 
 rm -f "$PROMPT_FILE"
 
-# Check for API errors
-if grep -q '"type":"error"' "$AGENT_LOG" 2>/dev/null; then
-    echo "  API error detected. Exiting for retry."
+# Detect agent failure: a non-zero exit (any backend) OR an adapter-specific error
+# marker in the log (Claude's stream-JSON errors out with exit 0). This replaces the
+# old Claude-only `"type":"error"` grep that let non-Claude failures pass silently.
+if [ "$AGENT_RC" -ne 0 ] || agent_detect_error "$AGENT_LOG"; then
+    echo "  Agent error detected (exit code $AGENT_RC). Exiting for retry."
     rm -f "$AGENT_LOG"
     exit 1
 fi

--- a/tests/test_agent_error_detection.sh
+++ b/tests/test_agent_error_detection.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Test: per-adapter agent error detection (P2.4, #30).
+# - claude.sh's agent_detect_error catches the Claude "type":"error" JSON marker.
+# - non-Claude adapters expose no agent_detect_error; evolve.sh's fallback returns
+#   non-zero (rely on process exit code instead of a Claude-specific grep).
+# Sources the real adapters — no copies.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AGENTS="$ROOT/templates/scripts/agents"
+
+pass=0; fail=0
+ok()   { echo "  ok: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+log="$(mktemp)"; trap 'rm -f "$log"' EXIT
+
+# ── claude.sh: detects the JSON error marker, ignores clean output ──
+( source "$AGENTS/claude.sh"
+  printf '%s\n' '{"type":"error","error":{"message":"overloaded"}}' > "$log"
+  agent_detect_error "$log" ) && ok "claude: detects \"type\":\"error\"" \
+                              || bad "claude: should detect \"type\":\"error\""
+
+( source "$AGENTS/claude.sh"
+  printf '%s\n' 'all good, feature implemented' > "$log"
+  agent_detect_error "$log" ) && bad "claude: false positive on clean log" \
+                              || ok "claude: clean log not flagged"
+
+# ── fallback: adapters without agent_detect_error rely on exit code ──
+# Replicates the evolve.sh guard: define the fallback only if unset.
+for adapter in codex opencode ollama; do
+  ( source "$AGENTS/$adapter.sh"
+    declare -f agent_detect_error >/dev/null || agent_detect_error() { return 1; }
+    printf '%s\n' 'Error: invalid api key' > "$log"
+    # plain-text error in log must NOT be self-detected — exit code is the signal
+    agent_detect_error "$log" ) && bad "$adapter: fallback should not grep-detect" \
+                                || ok "$adapter: defers to exit code (fallback returns non-zero)"
+done
+
+echo "----"
+echo "PASS: $pass  FAIL: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

Closes #30.

`evolve.sh` detected agent failures by greping the agent log for the Claude
stream-JSON marker `"type":"error"`. The codex/opencode/ollama adapters emit
plain text, so their auth/API failures **passed undetected** — the engine
thought the agent succeeded and corrupted the cycle silently. The main-session
`run_agent` call also masked the agent's real exit code via `| tee ... || true`.

## Changes

- **`agents/claude.sh`** — add `agent_detect_error <log>` preserving the
  `"type":"error"` grep (Claude can exit 0 yet emit an error in its JSON stream).
- **`evolve.sh`** — define a fallback `agent_detect_error() { return 1; }` for
  adapters that don't ship one; they now rely on the **process exit code**.
- **`evolve.sh`** — capture `run_agent`'s real exit code (`|| RC=$?`, since
  `pipefail` + `tee` otherwise masks it) and flag an error when `exit != 0`
  **OR** the adapter's detector fires. Replaces the Claude-only grep.

## Test

`tests/test_agent_error_detection.sh` (bash, matches repo convention) — sources
the real adapters and asserts: Claude detects the JSON marker / ignores clean
output; codex/opencode/ollama defer to exit code via the fallback. Verified the
acceptance criterion end-to-end: a forced 401 on the codex backend (plain-text
error, no JSON marker) is now detected via exit code instead of passing silently.

## Known limitations / scope

- Scoped to the **main session** `run_agent` call (the one the issue cites). The
  secondary best-effort calls (auto-fix loop, journal) keep `|| true` by design.
- A mid-session **timeout** (exit 124) is now treated as a failure → exit-for-retry,
  where it was previously swallowed. This is intentional and more correct, but is a
  behavior change worth calling out.
- Non-Claude adapters detect failure via exit code only; verifying each CLI's exact
  exit semantics is tracked separately in #31 (P2.5).