### PR TITLE
fix(evolve): correct codex adapter invocation; verify opencode/ollama (P2.5, #31)

### DIFF
--- a/templates/scripts/agents/codex.sh
+++ b/templates/scripts/agents/codex.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Agent adapter: Codex CLI (OpenAI)
+# Verified against codex-cli 0.141.0 (2026-06). The non-interactive entrypoint is
+# `codex exec` (NOT the old `codex --quiet`, which no longer exists). `exec` reads
+# the prompt from stdin when no PROMPT arg is given, runs with approvals disabled,
+# and exits non-zero on API/auth errors (so evolve.sh's exit-code check suffices).
 
 check_agent() {
     command -v codex &>/dev/null
@@ -12,10 +16,16 @@ run_agent() {
     local timeout_cmd="$3"
     local timeout="$4"
 
-    ${timeout_cmd:+$timeout_cmd "$timeout"} codex --quiet --model "$model" \
+    # NOTE: --sandbox workspace-write lets the agent edit the repo + run most
+    # build/test steps, but blocks network and out-of-workspace writes. Upgrade path:
+    # swap for --dangerously-bypass-approvals-and-sandbox in externally-sandboxed CI.
+    ${timeout_cmd:+$timeout_cmd "$timeout"} codex exec \
+        --model "$model" \
+        --sandbox workspace-write \
+        --skip-git-repo-check \
         < "$prompt_file" 2>&1
 }
 
 agent_env_hint() {
-    echo "OPENAI_API_KEY"
+    echo "OPENAI_API_KEY (or a ChatGPT login via 'codex login')"
 }

--- a/templates/scripts/agents/ollama.sh
+++ b/templates/scripts/agents/ollama.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Agent adapter: Ollama (local models)
+# Verified against ollama (2026-06): `ollama run <model>` reads the prompt from stdin.
+# Requires a running server ('ollama serve') and the model pulled locally; otherwise
+# the run exits non-zero with a "could not connect"/"model not found" error, which
+# evolve.sh surfaces via its exit-code check.
 
 check_agent() {
     command -v ollama &>/dev/null

--- a/templates/scripts/agents/opencode.sh
+++ b/templates/scripts/agents/opencode.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # Agent adapter: OpenCode CLI
+# Verified against opencode 1.17.8 (2026-06): `opencode run` reads the prompt from
+# stdin and the model flag takes a "provider/model" string (e.g. "anthropic/claude-..."
+# or "opencode/...-free"). A bare model name will not resolve. Exits non-zero on error.
 
 check_agent() {
     command -v opencode &>/dev/null

--- a/tests/test_adapter_invocations.sh
+++ b/tests/test_adapter_invocations.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Test: each non-Claude adapter's run_agent invokes its CLI with the correct
+# subcommand/flags (P2.5, #31). Offline — stubs each CLI on PATH and asserts the
+# args run_agent passes, so no API key or network is needed. Sources the real
+# adapters (no copies). Real end-to-end runs were verified manually against
+# codex-cli 0.141.0, opencode 1.17.8, and ollama.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+AGENTS="$ROOT/templates/scripts/agents"
+
+pass=0; fail=0
+ok()  { echo "  ok: $1"; pass=$((pass+1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+stubdir="$(mktemp -d)"
+prompt="$(mktemp)"; printf 'do the thing\n' > "$prompt"
+trap 'rm -rf "$stubdir" "$prompt"' EXIT
+
+# Stub every adapter CLI: print "ARGS:" + its argv, swallow stdin.
+for cli in codex opencode ollama; do
+    cat > "$stubdir/$cli" <<'STUB'
+#!/bin/bash
+cat >/dev/null   # consume the piped prompt
+echo "ARGS: $*"
+STUB
+    chmod +x "$stubdir/$cli"
+done
+
+run() { # <adapter> -> captured invocation line
+    ( PATH="$stubdir:$PATH"; source "$AGENTS/$1.sh"; run_agent "$prompt" "MODEL_X" "" "" )
+}
+
+assert_has()    { case "$2" in *"$1"*) ok "$3";;    *) bad "$3 — got: $2";; esac; }
+assert_lacks()  { case "$2" in *"$1"*) bad "$4 — got: $2";; *) ok "$3";; esac; }
+
+# ── codex: must use `exec`, workspace-write sandbox, and NOT the dead --quiet flag ──
+out="$(run codex)"
+assert_has  "exec"                  "$out" "codex: uses 'codex exec'"
+assert_has  "--sandbox workspace-write" "$out" "codex: sandbox workspace-write"
+assert_has  "--model MODEL_X"       "$out" "codex: forwards --model"
+assert_lacks "--quiet"              "$out" "codex: no dead --quiet flag" "codex: still passes --quiet"
+
+# ── opencode: `run --model <m>` (prompt via stdin) ──
+out="$(run opencode)"
+assert_has "run"            "$out" "opencode: uses 'opencode run'"
+assert_has "--model MODEL_X" "$out" "opencode: forwards --model"
+
+# ── ollama: `run <model>` (prompt via stdin) ──
+out="$(run ollama)"
+assert_has "run MODEL_X"   "$out" "ollama: 'ollama run <model>'"
+
+echo "----"
+echo "PASS: $pass  FAIL: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #31

## Problem
The codex/opencode/ollama agent adapters shipped with invocation flags that were never verified against the real CLIs. The **codex** adapter was actually broken: `codex --quiet --model …` → `error: unexpected argument '--quiet'`.

## What I did
Verified all three end-to-end against the installed CLIs (codex-cli 0.141.0, opencode 1.17.8, ollama):

| Adapter | Old | Result | Fix |
|---|---|---|---|
| **codex** | `codex --quiet --model` | ❌ invalid arg | `codex exec --model <m> --sandbox workspace-write --skip-git-repo-check` (reads stdin) |
| **opencode** | `opencode run --model <m> < stdin` | ✅ returned `PONG` | unchanged; added version/`provider/model` note |
| **ollama** | `ollama run <m> < stdin` | ✅ returned `PONG` | unchanged; added version/server-running note |

Each adapter now carries a dated version-assumption comment so future CLI drift is visible (per the issue's "Work" item).

## Acceptance
- [x] codex now uses the real non-interactive entrypoint and runs (the prior flag erred out before any request)
- [x] opencode runs a real one-shot prompt end-to-end (`PONG`)
- [x] ollama runs a real one-shot prompt end-to-end (`PONG`)
- [x] Each adapter annotated with a version assumption

## Tests
- `tests/test_adapter_invocations.sh` — offline (stubs each CLI on PATH), asserts the subcommand/flags each `run_agent` emits, incl. a regression guard that codex no longer passes `--quiet`. **7/7 pass.**
- `tests/test_agent_error_detection.sh` regression — **5/5 pass.**

## Design note
codex runs with `--sandbox workspace-write`: the agent can edit the repo and run most build/test steps, but not network or out-of-workspace writes. `evolve.sh` performs the git commit itself, so the agent only needs workspace writes. In-file upgrade path noted: swap for `--dangerously-bypass-approvals-and-sandbox` in externally-sandboxed CI.

## Known limitations
- `check_agent` still only checks the binary exists, not that `ollama serve` is running / a model is pulled — a failed run surfaces via exit code (per #30's detection), and the env hint documents the requirement.
- opencode/codex true end-to-end requires the user's own provider credentials; verified here with a ChatGPT login (codex) and a free opencode model.