### PR TITLE
feat(skills): respect existing conventions for mature repos (P2.6, #32)

### DIFF
--- a/templates/skills/evolve/SKILL.md
+++ b/templates/skills/evolve/SKILL.md
@@ -22,15 +22,15 @@ You are building software autonomously. Follow these rules exactly.
 
 1. Read .evolve/vision.md and .evolve/spec.md completely
 2. Read .evolve/JOURNAL.md — check what you've done before and what failed
-3. Examine the current project state — what exists, what's missing
-4. Understand what you're changing and WHY (must trace to vision or spec)
+3. Examine the current project state — what exists, what's missing. If the repo already has code but the spec is blank, also read its conventions (CONTRIBUTING, lint/format config, test layout, CI) and follow them — see rule 4 under "Making changes".
+4. Understand what you're changing and WHY (must trace to vision or spec — or, for an existing repo with a blank spec, to the project's own conventions)
 
 ## Making changes
 
 1. **Each change should be focused.** One feature, one fix, or one improvement per commit. Multiple commits per session is fine.
 2. **Write tests alongside features.** Every new capability should have a test.
 3. **Use surgical edits.** Don't rewrite entire files. Change the minimum needed.
-4. **Follow the spec's tech stack.** Use the languages, frameworks, and tools specified in .evolve/spec.md.
+4. **Follow the spec's tech stack.** Use the languages, frameworks, and tools specified in .evolve/spec.md. **If .evolve/spec.md is still the blank template (it still contains its unfilled placeholder comment — the `<!-- ... -->` block whose text begins "Replace this with your project's technical specification") and the repo already has code, the existing project wins:** match its languages, frameworks, lint/format config, test layout, and CI; don't introduce conflicting tooling or restructure to fit template defaults.
 5. **Update .evolve/spec.md checkboxes** after implementing features: `[ ]` → `[x]` for complete, `[ ]` → `[~]` for partial.
 
 ## After each change

--- a/templates/skills/plan/SKILL.md
+++ b/templates/skills/plan/SKILL.md
@@ -6,13 +6,35 @@ tools: [bash, read_file, write_file, list_files]
 
 # Planning
 
-You are planning a project from scratch based on .evolve/vision.md and .evolve/spec.md.
+You are planning a project based on .evolve/vision.md and .evolve/spec.md. This may be a
+greenfield build from scratch, or an existing repo that code-evolve was dropped into — check
+which before you plan (see "Respect existing conventions" below).
 
 ## When to use this skill
 
 - Day 0 (bootstrap) — plan the entire project structure
 - Before implementing a complex feature — plan the approach
 - When multiple spec features interact — plan the integration
+
+## Respect existing conventions (check this first)
+
+Before planning, decide whether this is greenfield or an existing repo:
+
+- **Existing repo** = there's already source code and git history beyond the `.evolve/` scaffold.
+- **Blank spec** = `.evolve/spec.md` still contains its unfilled placeholder comment — the `<!-- ... -->` block whose text begins "Replace this with your project's technical specification" (nobody filled it in).
+
+If it's an **existing repo with a blank spec**, the existing project's reality wins over template
+defaults. Before you plan anything, discover and adopt what's already there:
+
+- Read `CONTRIBUTING.md`, `README.md`, and any `docs/` for stated conventions.
+- Read the lint/format config (`.eslintrc*`, `ruff.toml`/`pyproject.toml`, `.prettierrc`, `rustfmt.toml`, etc.) and match the existing style.
+- Mirror the existing test layout and framework — don't introduce a second one.
+- Read the existing CI (`.github/workflows/`) to learn the real build/test/lint commands.
+- Follow the existing directory layout, naming, and dependency choices.
+
+Plan to extend the project *in its own idiom*. Do **not** introduce conflicting tooling, restructure
+the tree, or swap frameworks to match the template. Treat the existing code as the spec until someone
+fills `.evolve/spec.md` in.
 
 ## Process
 
@@ -56,7 +78,7 @@ This Session:
 
 ## Rules
 
-- Follow .evolve/spec.md's tech stack exactly. Don't substitute technologies.
+- Follow .evolve/spec.md's tech stack exactly. Don't substitute technologies. **But** if the spec is still the blank template and the repo already has code, the existing stack is the truth — follow that instead (see "Respect existing conventions" above).
 - Plan for testability from the start.
 - Keep the structure as simple as possible — add complexity only when needed.
 - Don't over-plan. Plan what you'll build THIS session, sketch the rest.

--- a/templates/skills/self-assess/SKILL.md
+++ b/templates/skills/self-assess/SKILL.md
@@ -10,7 +10,13 @@ You are assessing the project against its vision and specification.
 
 ## Process
 
-1. **Read .evolve/vision.md and .evolve/spec.md** completely
+1. **Read .evolve/vision.md and .evolve/spec.md** completely.
+   - **If .evolve/spec.md is still the blank template** (it still contains its unfilled placeholder
+     comment — the `<!-- ... -->` block whose text begins "Replace this with your project's technical
+     specification") **and the repo already has code**, the existing project is your spec. Read its
+     conventions — `CONTRIBUTING.md`, lint/format config, test layout, CI workflows — and assess
+     against *those*, not against template defaults. A gap is "doesn't match the existing project's
+     standards," not "doesn't match the template."
 2. **Read the current project state** — list files, read key modules
 3. **Compare spec features vs implementation**:
    - Which features from .evolve/spec.md are implemented?
@@ -30,6 +36,7 @@ You are assessing the project against its vision and specification.
 - Missing error handling — silent failures, unhelpful messages
 - Missing edge cases — empty input, invalid data, boundary conditions
 - UX gaps — confusing behavior, unclear output
+- Convention conflicts — code or tooling that fights the existing repo's style, lint/format config, test layout, or CI (when the spec is blank, these are real findings)
 
 ## Output
 

--- a/templates/state/IDENTITY.md
+++ b/templates/state/IDENTITY.md
@@ -10,7 +10,7 @@ From these, I build real, working software. Every session I make progress. Every
 
 ## My Rules
 
-1. **Vision drives everything.** Every change must trace back to .evolve/vision.md or .evolve/spec.md. No feature creep.
+1. **Vision drives everything.** Every change must trace back to .evolve/vision.md or .evolve/spec.md. No feature creep. (Exception: see rule 11 — when I'm injected into an existing repo with a blank spec, its reality wins.)
 2. **Every change must pass tests.** If I break the build, I revert and journal the failure.
 3. **I write a journal entry every session.** Honest. What I tried, what worked, what didn't.
 4. **I never delete my journal.** It's my memory across sessions.
@@ -20,6 +20,7 @@ From these, I build real, working software. Every session I make progress. Every
 8. **I can use the internet** to learn, and I write what I learn to LEARNINGS.md.
 9. **I build incrementally.** Small, working steps. Each commit should leave the project in a working state.
 10. **I detect and adapt.** I figure out the right tools, frameworks, and build commands from the project's own files.
+11. **An existing repo's reality wins over template defaults.** If the project already has its own code and history (more than the `.evolve/` scaffold) *and* `.evolve/spec.md` is still the blank template (it still contains its unfilled placeholder comment — the `<!-- ... -->` block whose text begins "Replace this with your project's technical specification"), I do **not** impose template conventions. I read and honor what's already there — CONTRIBUTING, lint/format config, test layout, CI, naming and directory style — and match it. I never introduce conflicting tooling. The "follow the spec exactly" rules apply only once someone fills `.evolve/spec.md` in.
 
 ## What I Have
 


### PR DESCRIPTION
Closes #32

## What

Adds a "respect existing conventions" pass so that when code-evolve is dropped into a repo that **already has code/CI/lint/style but a blank `.evolve/spec.md`**, the agent reads and honors the existing project's conventions instead of imposing template defaults. Reconciles the existing "follow spec exactly" instructions with "an existing repo's reality wins when the spec is still the blank template."

## Why

The skills + IDENTITY were greenfield/spec-driven and never told the agent to discover an existing mature repo's conventions (`plan/SKILL.md` said "from scratch"; `self-assess` only compared against `spec.md`; evolve/IDENTITY repeatedly asserted "follow spec's tech stack exactly"). Injected into a real project with a blank template spec, the agent could impose template conventions and conflict with the existing code.

## Changes (template markdown only)

- **`templates/state/IDENTITY.md`** — new rule 11 (existing repo's reality wins over template defaults; reconciles rule 1).
- **`templates/skills/plan/SKILL.md`** — reframe "from scratch"; gated **"Respect existing conventions"** discovery step (CONTRIBUTING, lint/format config, test layout, CI); reconcile the "follow spec exactly" rule.
- **`templates/skills/self-assess/SKILL.md`** — assess against existing conventions/CI/lint when the spec is blank; add a convention-conflict finding type.
- **`templates/skills/evolve/SKILL.md`** — reconcile "follow the spec's tech stack" with existing-repo reality in both "Before any code change" and "Making changes".

## Gate signals (concrete, no new tooling)

- **"Already has code"** — source files / git history beyond the `.evolve/` scaffold.
- **"Blank spec"** — `.evolve/spec.md` still contains its unfilled placeholder comment (text begins `Replace this with your project's technical specification`, matched to the actual template text in `templates/state/spec.md`).

## Acceptance

> On an existing repo with no filled spec, the agent reads and follows existing conventions rather than imposing defaults.

Met: all four behavior files now gate on "existing code + blank spec" and instruct the agent to discover and follow CONTRIBUTING / lint+format config / test layout / CI.

## Review

`codex review` (cross-family) flagged one real issue — the gate wording originally referenced a literal `<!-- Replace ... -->` marker that doesn't match the actual two-line placeholder in `spec.md`. Fixed in all four files to reference the real placeholder text.

## Known limitations / testing

Behavioral template-doc change — no unit test (the jest harness lands separately in #33; `npm test` is currently broken there). Verified by diff review + cross-family review; no `src/` touched, so the package build is unaffected.