### PR TITLE
feat(ci): make bundled CI workflow agent-aware (P2.7, #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,11 +328,11 @@ Run it however fits your workflow:
 - API key stored securely in `.evolve/.env` (mode 600, gitignored)
 - Logs in `.evolve/evolve.log`
 
-**Cloud** — `code-evolve init --with-ci` *(Claude backend only, for now)*
+**Cloud** — `code-evolve init --with-ci`
 - GitHub Actions installed as `.github/workflows/evolve.yml` and `evolve-ci.yml`
 - Runs every 4 hours with 3-attempt retry logic
-- Set `ANTHROPIC_API_KEY` in repo secrets; CI always uses `api-key` mode regardless of your local `--auth-mode`
-- The bundled workflow currently supports Claude only — `--with-ci` is skipped for `codex`/`opencode`/`ollama`. Use **Local** execution for those backends; per-agent CI is in progress.
+- The workflow is templated for your `--agent`: it installs the matching CLI, sets `AGENT`/`MODEL`, and wires the right secret. `init` prints the exact `gh secret set …` command for your backend (`ANTHROPIC_API_KEY` for Claude, `OPENAI_API_KEY` for Codex, the provider key for opencode). OAuth is local-only, so CI always uses `api-key` mode regardless of your local `--auth-mode`.
+- `ollama` runs models locally and isn't supported on hosted CI runners, so `--with-ci` is skipped for it — use **Local** execution.
 
 Both run the same engine. Mix and match.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,7 +11,7 @@ The **core evolution engine is real and surprisingly solid** for the happy path 
 
 But the product the user is describing — *"open any repo, install, get interviewed, turn it on"* — has **two hard functional blockers** and a **missing guided-install layer**:
 
-- ~~**The GitHub Action path is currently dead** — workflows install into a subdirectory GitHub never executes (P0.1).~~ **RESOLVED** in #36 — workflows now install directly into `.github/workflows/` with collision-safe names. (Per-agent CI for non-Claude backends remains a follow-up.)
+- ~~**The GitHub Action path is currently dead** — workflows install into a subdirectory GitHub never executes (P0.1).~~ **RESOLVED** in #36 — workflows now install directly into `.github/workflows/` with collision-safe names. (Per-agent CI landed in #37 — the workflow is templated per backend.)
 - **True greenfield (zero-commit) repos abort immediately** on session start (P0.2).
 - **Guided onboarding is still thin.** `init` now prompts for the agent + auth backend on a TTY (P1.1, #20), but there is still no spec generator, the existing vision interview is hardcoded (not LLM-driven) and not wired into `init`, and there is no "choose local / CI / both + pick a schedule" step (P1.x).
 
@@ -36,7 +36,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 ## Gaps by dimension
 
 ### 1. Functional blockers (advertised feature literally doesn't work)
-- ~~**CI workflows install to `.github/workflows/evolve/`** — GitHub Actions only executes workflows directly in `.github/workflows/`, so nested workflows never ran.~~ **RESOLVED in #36** — workflows now install directly into `.github/workflows/` as `evolve.yml`/`evolve-ci.yml`. Remaining open work: the bundled workflow is Claude-only, so `--with-ci` is skipped for non-Claude backends (per-agent CI tracked in #37). → **P0.1 done**
+- ~~**CI workflows install to `.github/workflows/evolve/`** — GitHub Actions only executes workflows directly in `.github/workflows/`, so nested workflows never ran.~~ **RESOLVED in #36** — workflows now install directly into `.github/workflows/` as `evolve.yml`/`evolve-ci.yml`. Per-agent CI landed in #37 — `--with-ci` now templates `evolve.yml` for the configured agent (CLI install + `AGENT`/`MODEL` + the right secret); only `ollama` is skipped as local-only. → **P0.1 done**
 - **Greenfield abort.** `evolve.sh:277` runs `git rev-parse HEAD` under `set -euo pipefail` (`:23`). On a freshly `git init`'d repo with no commits this exits non-zero and kills the session before any work. → **P0.2**
 
 ### 2. Guided installation (the "turn on" experience — the heart of the ask)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,7 @@ import {
   isValidAgent,
   getAgentEnvHint,
   getAgentEnvKey,
+  getAgentCiProfile,
   getDefaultModel,
   getSupportedAgents,
   resolveAgentSelection,
@@ -18,6 +19,7 @@ import {
   isValidMode,
   AuthMode,
   ExecutionMode,
+  AgentCiProfile,
 } from '../utils/config';
 import { installLocalSchedule, hourlyCron, parseInterval } from './start';
 
@@ -240,14 +242,15 @@ export async function runInit(options: InitOptions): Promise<void> {
     // Install GitHub Actions workflows directly into .github/workflows/ so they actually run.
     // (GitHub only executes workflows located directly in .github/workflows/, not subdirectories.)
     // Renamed to evolve-* so they never clobber a target repo's own ci.yml/evolve.yml.
-    // The bundled CI workflow is Claude-only today (installs claude-code, uses
-    // ANTHROPIC_API_KEY). Skip the install for other backends rather than schedule a
-    // workflow that would run the wrong agent / fail every cycle. Tracked for per-agent CI.
-    if (wantCi && agent !== 'claude') {
+    // The evolve workflow is templated for the configured agent (CLI install, secret,
+    // AGENT/MODEL). Ollama has no CI profile — it needs local model compute — so its
+    // install is skipped rather than scheduling a workflow that times out every cycle.
+    const ciProfile = wantCi ? getAgentCiProfile(agent) : null;
+    if (wantCi && !ciProfile) {
       console.warn(
-        `  ⚠ Skipping GitHub Actions install: the bundled workflow supports the Claude backend only and would run the wrong agent in CI. Use local execution (code-evolve start) for "${agent}". Per-agent CI is tracked as a follow-up.`
+        `  ⚠ Skipping GitHub Actions install: "${agent}" runs models locally and isn't supported on hosted CI runners. Use local execution (code-evolve start) for "${agent}".`
       );
-    } else if (wantCi) {
+    } else if (wantCi && ciProfile) {
       console.log('Installing GitHub Actions workflows...');
       const workflowDir = projectFile('.github/workflows');
       fs.mkdirSync(workflowDir, { recursive: true });
@@ -266,12 +269,10 @@ export async function runInit(options: InitOptions): Promise<void> {
             `  ⚠ ${path.relative(process.cwd(), destPath)} already exists — skipping; code-evolve's ${destName} was NOT installed (rename or remove the existing file to install it)`
           );
         } else {
-          // Template the cadence into the evolve workflow's schedule before writing,
-          // so --every reaches CI too (the other workflow has no cron to template).
+          // Template the cadence + agent into the evolve workflow before writing, so
+          // --every and the chosen backend reach CI. (evolve-ci.yml has nothing to template.)
           if (src === 'evolve.yml') {
-            const templated = fs
-              .readFileSync(srcPath, 'utf8')
-              .replace(/-\s*cron:\s*'[^']*'[^\n]*/, `- cron: '${hourlyCron(hours)}'  # every ${hours}h`);
+            const templated = templateEvolveWorkflow(fs.readFileSync(srcPath, 'utf8'), agent, hours, ciProfile);
             fs.writeFileSync(destPath, templated);
           } else {
             fs.copyFileSync(srcPath, destPath);
@@ -279,6 +280,7 @@ export async function runInit(options: InitOptions): Promise<void> {
           console.log(`  Created ${path.relative(process.cwd(), destPath)}`);
         }
       }
+      console.log(`  CI secret: ${ciProfile.secretHint}`);
     }
 
     // Install the local cron schedule for local/both modes. Native Windows has
@@ -397,6 +399,30 @@ function runInterview(name: 'vision' | 'spec'): boolean {
   }
   const after = read();
   return after.trim() !== '' && after !== before;
+}
+
+/**
+ * Template the bundled evolve.yml for the configured agent: the cron cadence, the
+ * AGENT/MODEL job env, the CLI install step, and the secret env block (between the
+ * `# code-evolve:secrets` markers). For the Claude default these replacements are
+ * no-ops, so the workflow round-trips unchanged.
+ */
+function templateEvolveWorkflow(
+  src: string,
+  agent: string,
+  hours: number,
+  profile: AgentCiProfile,
+): string {
+  return src
+    .replace(/-\s*cron:\s*'[^']*'[^\n]*/, `- cron: '${hourlyCron(hours)}'  # every ${hours}h`)
+    .replace(/^( *AGENT: ).*$/m, `$1${agent}`)
+    .replace(/^( *MODEL: ).*$/m, `$1${getDefaultModel(agent)}`)
+    .replace('npm install -g @anthropic-ai/claude-code', profile.cliInstall)
+    // The secret block is repeated on each agent run step — replace every occurrence.
+    .replace(
+      /^ *# code-evolve:secrets[\s\S]*?# code-evolve:secrets-end\n/gm,
+      profile.envBlock,
+    );
 }
 
 /** Copy directory recursively, overwriting all files (for framework code). */

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -250,6 +250,11 @@ export async function runInit(options: InitOptions): Promise<void> {
       console.warn(
         `  ⚠ Skipping GitHub Actions install: "${agent}" runs models locally and isn't supported on hosted CI runners. Use local execution (code-evolve start) for "${agent}".`
       );
+      // Don't persist a CI mode we just refused to install — local is the only
+      // viable mode for this backend, so reflect that in config.json/status.
+      if (mode === 'ci' || mode === 'both') {
+        mode = 'local';
+      }
     } else if (wantCi && ciProfile) {
       console.log('Installing GitHub Actions workflows...');
       const workflowDir = projectFile('.github/workflows');

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -96,12 +96,75 @@ export function getAgentEnvKey(agent: string, authMode?: AuthMode): string {
 const AGENT_DEFAULT_MODELS: Record<string, string> = {
   claude: 'claude-sonnet-4-6',
   codex: 'o4-mini',
-  opencode: 'claude-sonnet-4-6',
+  // opencode's `run --model` needs a provider-qualified value (see agents/opencode.sh);
+  // a bare model name won't resolve.
+  opencode: 'anthropic/claude-sonnet-4-6',
   ollama: 'llama3',
 };
 
 export function getDefaultModel(agent: string): string {
   return AGENT_DEFAULT_MODELS[agent] || 'claude-sonnet-4-6';
+}
+
+/**
+ * CI-templating profile for a backend: how the bundled GitHub Actions workflow
+ * installs the CLI and which secret it wires. Returns `null` for agents that
+ * can't run on hosted runners (ollama needs local model compute), signalling
+ * init to skip the CI install rather than schedule a workflow that times out.
+ */
+export interface AgentCiProfile {
+  /** Shell command for the workflow's "Install agent CLI" step. */
+  cliInstall: string;
+  /** YAML lines (6-space indented, with markers) for the job-level secret env. */
+  envBlock: string;
+  /** Post-install hint, e.g. the `gh secret set` command for the backend. */
+  secretHint: string;
+}
+
+/**
+ * Build the templated secret env block placed on each agent run step (between the
+ * workflow's `# code-evolve:secrets` markers). Step-level `env:` is indented 10
+ * spaces — keeping secrets off the job scope so third-party setup actions never see them.
+ */
+function secretEnvBlock(lines: string[]): string {
+  const indent = '          ';
+  const body = lines.map((l) => `${indent}${l}`).join('\n');
+  return `${indent}# code-evolve:secrets — agent backend secrets (templated by init)\n${body}\n${indent}# code-evolve:secrets-end\n`;
+}
+
+export function getAgentCiProfile(agent: string): AgentCiProfile | null {
+  switch (agent) {
+    case 'claude':
+      // CI is always api-key (OAuth is local-only), regardless of local authMode.
+      return {
+        cliInstall: 'npm install -g @anthropic-ai/claude-code',
+        envBlock: secretEnvBlock([
+          'ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}',
+          'CLAUDE_AUTH_MODE: api-key',
+        ]),
+        secretHint: 'gh secret set ANTHROPIC_API_KEY',
+      };
+    case 'codex':
+      return {
+        cliInstall: 'npm install -g @openai/codex',
+        envBlock: secretEnvBlock(['OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}']),
+        secretHint: 'gh secret set OPENAI_API_KEY',
+      };
+    case 'opencode':
+      // Provider-dependent: ship both keys so either configured provider works.
+      return {
+        cliInstall: 'npm install -g opencode-ai',
+        envBlock: secretEnvBlock([
+          'OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}',
+          'ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}',
+        ]),
+        // Default opencode model is Anthropic-provider, so lead with that secret.
+        secretHint: 'gh secret set ANTHROPIC_API_KEY   # or OPENAI_API_KEY, per your opencode provider/model',
+      };
+    case 'ollama':
+    default:
+      return null; // local-only — not viable on hosted CI runners
+  }
 }
 
 export function getAgentEnvHint(agent: string, authMode?: AuthMode): string {

--- a/templates/workflows/evolve.yml
+++ b/templates/workflows/evolve.yml
@@ -14,6 +14,16 @@ jobs:
   evolve:
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    # Non-secret config is shared at job scope. AGENT/MODEL are templated by
+    # `code-evolve init` for the configured agent (values below are the Claude
+    # defaults). Secrets are deliberately NOT here — they're scoped to the steps
+    # that need them so third-party setup actions never see them.
+    env:
+      AGENT: claude
+      MODEL: claude-sonnet-4-6
+      REPO: ${{ github.repository }}
+      FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
+      EVOLVE_DIR: .evolve
 
     steps:
       - name: Checkout
@@ -61,7 +71,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Install Claude Code CLI
+      - name: Install agent CLI
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Setup GitHub CLI
@@ -78,14 +88,11 @@ jobs:
         id: attempt1
         continue-on-error: true
         env:
-          # OAuth auth is local-only. CI always requires ANTHROPIC_API_KEY.
-          # If your local setup uses OAuth, you must still set this secret for CI.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # code-evolve:secrets — agent backend secrets (templated by init)
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_AUTH_MODE: api-key
-          REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
-          EVOLVE_DIR: .evolve
+          # code-evolve:secrets-end
         run: |
           chmod +x .evolve/scripts/evolve.sh
           .evolve/scripts/evolve.sh
@@ -95,13 +102,11 @@ jobs:
         if: steps.attempt1.outcome == 'failure'
         continue-on-error: true
         env:
-          # OAuth auth is local-only. CI always requires ANTHROPIC_API_KEY.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # code-evolve:secrets — agent backend secrets (templated by init)
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_AUTH_MODE: api-key
-          REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
-          EVOLVE_DIR: .evolve
+          # code-evolve:secrets-end
         run: |
           echo "Waiting 15 minutes before retry..."
           sleep 900
@@ -110,13 +115,11 @@ jobs:
       - name: Retry after 45min
         if: steps.attempt1.outcome == 'failure' && steps.attempt2.outcome == 'failure'
         env:
-          # OAuth auth is local-only. CI always requires ANTHROPIC_API_KEY.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # code-evolve:secrets — agent backend secrets (templated by init)
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_AUTH_MODE: api-key
-          REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
-          EVOLVE_DIR: .evolve
+          # code-evolve:secrets-end
         run: |
           echo "Waiting 45 minutes before retry..."
           sleep 2700

--- a/tests/test_ci_agent_templating.sh
+++ b/tests/test_ci_agent_templating.sh
@@ -69,6 +69,8 @@ D=$(mktemp -d)
 OUT=$( cd "$D" && git init -q && node "$CLI" init --agent ollama --with-ci </dev/null 2>&1 )
 check "ollama: CI workflow skipped"   "$([ -f "$D/.github/workflows/evolve.yml" ] && echo yes || echo no)" "no"
 has   "ollama: skip explained"        "$OUT" "local"
+# Don't persist a CI mode that was refused — normalize to local (issue #37 review).
+check "ollama: mode normalized off ci" "$(node -e "console.log(require('$D/.evolve/config.json').mode)")" "local"
 rm -rf "$D"
 
 rm -rf "$STUB"

--- a/tests/test_ci_agent_templating.sh
+++ b/tests/test_ci_agent_templating.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Test: `code-evolve init --agent <X> --with-ci` templates the bundled GitHub
+# Actions workflow (evolve.yml) for the configured backend — installing the right
+# CLI, wiring the right secret, and setting AGENT/MODEL so evolve.sh sources the
+# matching adapter (not always Claude).
+# Regression test for issue #37 (P2.7).
+#
+# Drives the REAL compiled CLI, non-TTY (piped stdin) so no interactive prompt
+# fires. Stub agent binaries on PATH satisfy the dependency check.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI="$ROOT/dist/cli.js"
+
+[ -f "$CLI" ] || ( cd "$ROOT" && npm run build >/dev/null 2>&1 )
+
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (got '$2', want '$3')"; fail=$((fail+1)); fi }
+has()   { if echo "$2" | grep -qF -- "$3"; then echo "  ok: $1"; pass=$((pass+1)); else echo "  FAIL: $1 (missing '$3')"; fail=$((fail+1)); fi }
+hasnt() { if echo "$2" | grep -qF -- "$3"; then echo "  FAIL: $1 (unexpected '$3')"; fail=$((fail+1)); else echo "  ok: $1"; pass=$((pass+1)); fi }
+
+# Stub all four agent binaries so checkDependencies passes for any --agent.
+STUB=$(mktemp -d)
+for b in claude codex opencode ollama; do
+  printf '#!/bin/bash\necho "%s 0.0.0-stub"\n' "$b" > "$STUB/$b"
+  chmod +x "$STUB/$b"
+done
+export PATH="$STUB:$PATH"
+unset ANTHROPIC_API_KEY OPENAI_API_KEY
+
+run_init() {  # $1 = agent
+  local dir; dir=$(mktemp -d)
+  ( cd "$dir" && git init -q && node "$CLI" init --agent "$1" --with-ci </dev/null >/dev/null 2>&1 )
+  echo "$dir"
+}
+
+# ── codex: workflow installs Codex CLI, uses OPENAI_API_KEY, runs codex adapter ──
+D=$(run_init codex)
+WF="$D/.github/workflows/evolve.yml"
+check "codex: workflow installed" "$([ -f "$WF" ] && echo yes || echo no)" "yes"
+YML=$(cat "$WF" 2>/dev/null || echo "")
+has   "codex: installs Codex CLI"     "$YML" "npm install -g @openai/codex"
+has   "codex: uses OPENAI_API_KEY"    "$YML" "OPENAI_API_KEY: \${{ secrets.OPENAI_API_KEY }}"
+has   "codex: sets AGENT=codex"       "$YML" "AGENT: codex"
+has   "codex: sets MODEL=o4-mini"     "$YML" "MODEL: o4-mini"
+hasnt "codex: no claude CLI install"  "$YML" "@anthropic-ai/claude-code"
+hasnt "codex: no ANTHROPIC secret"    "$YML" "ANTHROPIC_API_KEY"
+rm -rf "$D"
+
+# ── claude: default backend still produces a valid Claude workflow ──
+D=$(run_init claude)
+YML=$(cat "$D/.github/workflows/evolve.yml" 2>/dev/null || echo "")
+has   "claude: installs claude-code"  "$YML" "npm install -g @anthropic-ai/claude-code"
+has   "claude: uses ANTHROPIC_API_KEY" "$YML" "ANTHROPIC_API_KEY: \${{ secrets.ANTHROPIC_API_KEY }}"
+has   "claude: sets AGENT=claude"     "$YML" "AGENT: claude"
+rm -rf "$D"
+
+# ── opencode: installs opencode CLI, provider keys present ──
+D=$(run_init opencode)
+YML=$(cat "$D/.github/workflows/evolve.yml" 2>/dev/null || echo "")
+has   "opencode: installs opencode"   "$YML" "npm install -g opencode-ai"
+has   "opencode: sets AGENT=opencode" "$YML" "AGENT: opencode"
+# opencode needs a provider-qualified model — a bare name won't resolve (agents/opencode.sh).
+has   "opencode: provider-qualified MODEL" "$YML" "MODEL: anthropic/claude-sonnet-4-6"
+rm -rf "$D"
+
+# ── ollama: local-only — CI install is skipped (no workflow) ──
+D=$(mktemp -d)
+OUT=$( cd "$D" && git init -q && node "$CLI" init --agent ollama --with-ci </dev/null 2>&1 )
+check "ollama: CI workflow skipped"   "$([ -f "$D/.github/workflows/evolve.yml" ] && echo yes || echo no)" "no"
+has   "ollama: skip explained"        "$OUT" "local"
+rm -rf "$D"
+
+rm -rf "$STUB"
+echo "---"
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
Closes #37. `code-evolve init --agent <X> --with-ci` now **templates** the bundled
`.github/workflows/evolve.yml` for the configured backend instead of skipping CI for
non-Claude agents (the #36 stopgap).

The generated workflow:
- installs the matching CLI (`@anthropic-ai/claude-code` / `@openai/codex` / `opencode-ai`),
- sets `AGENT` + `MODEL` at job scope so `evolve.sh` sources the right adapter,
- wires the correct secret env (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / both for opencode),
- and `init` prints the exact `gh secret set …` hint for the backend.

`ollama` runs models locally and isn't viable on hosted runners, so it has no CI
profile — `--with-ci` skips it with a clear "use local execution" message.

## Changes
- `src/utils/config.ts` — `getAgentCiProfile(agent)` (claude/codex/opencode → profile, ollama → `null`); fixed `getDefaultModel('opencode')` to provider-qualified `anthropic/claude-sonnet-4-6` (a bare name doesn't resolve per `agents/opencode.sh`).
- `src/commands/init.ts` — `templateEvolveWorkflow()`; replaced the `agent !== 'claude'` skip with profile-driven templating + secret hint.
- `templates/workflows/evolve.yml` — `AGENT`/`MODEL` + non-secret config hoisted to job scope; **secrets kept per agent run step** (markers `# code-evolve:secrets … secrets-end`) so third-party setup actions never see them.
- `tests/test_ci_agent_templating.sh` — new regression test (codex/claude/opencode/ollama).
- Docs: README + `docs/STATUS.md` flipped from "Claude-only CI".

## Verification
- Acceptance demoed: `init --agent codex --with-ci` → workflow installs Codex CLI, uses `OPENAI_API_KEY` (0 ANTHROPIC refs), `AGENT: codex` / `MODEL: o4-mini`, no `claude-code`, valid YAML. `ollama` skipped. `eject` still removes the restructured managed workflow.
- New test: 15/15. Full shell-test sweep: no regressions. `npm run lint`/`build` clean.
- Cross-family review (`codex review`) clean after addressing 3 findings: opencode default model, **job-level secret exposure (P1)**, and opencode secret hint alignment.

## Known limitations
- The package CI (`ci.yml`) runs build+lint only, not the shell tests (jest harness is tracked in #33). New test was run locally.
- opencode ships both provider keys as secrets; the active one depends on the configured model/provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI workflow generation now templates per selected agent/backend, including agent-specific CLI install, model configuration, and correct secret wiring.
  * Non-secret settings are applied at the workflow job level; secret blocks are clearly scoped.

* **Bug Fixes**
  * Hosted CI is skipped for local-only setups (notably `ollama`), with clearer warnings and init output guidance.
  * Workflow installation behavior and naming are updated to place files directly under `.github/workflows/` safely.

* **Documentation**
  * Updated “Local vs. Cloud” and CI status notes to reflect the per-agent CI behavior.

* **Tests**
  * Added regression tests covering workflow templating across multiple agents and verifying `ollama` skip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->