### PR TITLE
docs: fix CLAUDE.md / package.json metadata drift (P3.2, #34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,4 +101,4 @@ These must not be modified by the evolution agent:
 - `.evolve/scripts/evolve.sh` — orchestrator
 - `.evolve/scripts/format_issues.py` — input sanitization
 - `.github/workflows/evolve.yml` — auto-evolution workflow
-- `.github/workflows/ci.yml` — CI/CD safety net (installed by `init --with-ci`)
+- `.github/workflows/evolve-ci.yml` — CI/CD safety net (installed by `init --with-ci` from `templates/workflows/ci.yml`, renamed so it never clobbers the target repo's own `ci.yml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,28 +13,59 @@ session after session using Claude Code CLI.
 
 ```
 code-evolve/                  # npm package source
-├── package.json              # npm package config (bin: code-evolve)
+├── package.json              # npm package config (bin: code-evolve, ce)
 ├── tsconfig.json             # TypeScript config
+├── jest.config.js            # Jest (ts-jest) config
 ├── src/                      # CLI source (TypeScript)
 │   ├── cli.ts                # Entrypoint (commander)
-│   ├── commands/
+│   ├── commands/             # One file per subcommand (see Commands below)
 │   │   ├── init.ts           # code-evolve init (exports runInit)
-│   │   ├── setup.ts          # code-evolve setup (guided wizard → runInit)
+│   │   ├── setup.ts          # code-evolve setup (guided onboarding wizard)
+│   │   ├── start.ts          # code-evolve start (set up recurring cron)
+│   │   ├── stop.ts           # code-evolve stop (remove cron)
 │   │   ├── run.ts            # code-evolve run
 │   │   ├── status.ts         # code-evolve status
-│   │   └── eject.ts          # code-evolve eject
+│   │   ├── eject.ts          # code-evolve eject
+│   │   ├── migrate.ts        # code-evolve migrate
+│   │   ├── vision.ts         # code-evolve vision (guided interview)
+│   │   ├── spec.ts           # code-evolve spec (guided interview)
+│   │   └── proof.ts          # code-evolve proof (PROOF9 quality gates)
 │   └── utils/
 │       ├── paths.ts          # Path resolution
 │       ├── checks.ts         # Dependency checking
-│       └── output.ts         # TTY/JSON output
+│       ├── output.ts         # TTY/JSON output
+│       ├── agent.ts          # Agent backend invocation
+│       ├── config.ts         # Agent/mode selection + config I/O
+│       ├── interview.ts      # Guided vision/spec interview engine
+│       ├── migrate.ts        # Spec/vision document migration
+│       ├── proof.ts          # PROOF9 requirements management
+│       └── __tests__/        # Jest unit tests
 ├── templates/                # Files installed by `init`
-│   ├── scripts/              # evolve.sh, detect_stack.sh, format_issues.py
-│   ├── skills/               # Agent behavior definitions (5 SKILL.md files)
-│   ├── state/                # IDENTITY.md, JOURNAL.md, LEARNINGS.md, DAY_COUNT, vision.md, spec.md
+│   ├── scripts/              # evolve.sh, detect_stack.sh, format_issues.py, agents/ (per-backend adapters)
+│   ├── skills/               # Agent behavior definitions (5 skill dirs, each a SKILL.md)
+│   ├── state/                # IDENTITY.md, JOURNAL.md, LEARNINGS.md, REQUIREMENTS.md, DAY_COUNT, vision.md, spec.md
 │   └── workflows/            # GitHub Actions (evolve.yml, ci.yml)
 ├── dist/                     # Compiled output (gitignored)
 └── .github/workflows/        # CI for this package
 ```
+
+## Commands
+
+The CLI ships 11 subcommands (registered in `src/cli.ts`; also available as `ce`):
+
+| Command | Purpose |
+|---------|---------|
+| `init` | Initialize `.evolve/` in the current project |
+| `setup` | Guided onboarding wizard: agent → interview → mode → schedule → ready |
+| `start` | Start the evolution engine (sets up a recurring local cron job) |
+| `stop` | Stop the evolution engine (removes the local cron job) |
+| `run` | Run one evolution cycle |
+| `status` | Show current evolution state |
+| `eject` | Remove code-evolve framework, keep project files |
+| `migrate` | Convert an existing spec or vision document into code-evolve format |
+| `vision` | Guided interview to generate `.evolve/vision.md` |
+| `spec` | Guided interview to generate `.evolve/spec.md` |
+| `proof` | PROOF9 quality gates and requirements management |
 
 ## Development
 
@@ -69,4 +100,5 @@ These must not be modified by the evolution agent:
 - `.evolve/IDENTITY.md` — agent constitution
 - `.evolve/scripts/evolve.sh` — orchestrator
 - `.evolve/scripts/format_issues.py` — input sanitization
-- `.github/workflows/evolve.yml`, `.github/workflows/evolve-ci.yml` — CI/CD safety net
+- `.github/workflows/evolve.yml` — auto-evolution workflow
+- `.github/workflows/ci.yml` — CI/CD safety net (installed by `init --with-ci`)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,27 @@
 {
   "name": "code-evolve",
   "version": "0.1.0",
-  "description": "Self-evolving project builder powered by Claude Code",
+  "description": "Turn any project into a self-evolving codebase — autonomous build-and-improve cycles driven by Claude Code, Codex, OpenCode, or Ollama.",
+  "keywords": [
+    "ai",
+    "agent",
+    "autonomous",
+    "code-generation",
+    "claude",
+    "claude-code",
+    "codex",
+    "opencode",
+    "ollama",
+    "self-evolving",
+    "cli",
+    "automation"
+  ],
   "author": "FRANK BRIA <frank@frankbria.com>",
   "license": "MIT",
+  "homepage": "https://github.com/frankbria/code-evolve#readme",
+  "bugs": {
+    "url": "https://github.com/frankbria/code-evolve/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/frankbria/code-evolve"


### PR DESCRIPTION
## Summary

Docs and metadata had drifted from the shipped code. This brings them back in sync.

### CLAUDE.md
- **Repository tree** listed only 5 commands and 3 utils — the CLI actually ships **11 commands** and `src/utils/` has 8 modules. Added a **Commands** table and corrected the `commands/`, `utils/`, `scripts/` (incl. `agents/`), `skills/` (5 dirs, each a `SKILL.md`), `state/` (incl. `REQUIREMENTS.md`), and `workflows/` entries to match reality.
- **Protected Files** referenced a nonexistent `.github/workflows/evolve-ci.yml`. The installed workflows are `evolve.yml` and `ci.yml` — corrected.

### package.json
- Reworded `description` to reflect **multi-agent** support (Claude Code, Codex, OpenCode, Ollama) instead of "powered by Claude Code".
- Added `keywords`, `homepage`, and `bugs` for npm discoverability.

### CI
- The package CI (`.github/workflows/ci.yml`) **already runs `npm test`** (landed with P3.1, #33), so the issue's "fold in npm test" item was already satisfied — no workflow change needed.

## Verification
Every doc claim was checked against the source:
- `src/cli.ts` registers 11 subcommands → matches the new Commands table.
- `ls src/utils templates/{scripts,skills,state,workflows}` → matches the updated tree.
- No `evolve-ci.yml` exists anywhere → Protected Files fixed.
- `npm run build`, `npm run lint`, `npm test` all green.
- `codex review --uncommitted`: no findings.

## Known Limitations
Docs/metadata only — no runtime behavior changes. `src/cli.ts`'s inline `--help` description string is left as-is (out of scope; not part of the published package metadata).

Closes #34

https://claude.ai/code/session_01VpLN9ubKwCeaDRhuwDLF9q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance to reflect the current CLI layout, including the full set of available commands and utilities.
  * Expanded the “protected files” list to include the latest workflow files and clarified the safety-net behavior for CI workflow installation.

* **Chores**
  * Refreshed project metadata (app description, keywords, homepage, and bug-report URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->