### PR TITLE
fix(cli): make schedule.json honest; correct --force help (P3.3, #35)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -59,7 +59,7 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 ### 4. Package polish & accuracy
 - **`npm test` is broken** — jest declared but not installed, zero test files. → **P3.1**
 - **CLAUDE.md & package.json drift** — CLAUDE.md lists 4 commands (code ships 9) and flat skills (actually 5 dirs); package.json missing `keywords`/`homepage`/`bugs`. → **P3.2**
-- **`schedule.json` is dead config** (written/displayed but never consumed); `--force` help text is misleading. → **P3.3**
+- ~~**`schedule.json` is dead config** (written/displayed but never consumed); `--force` help text is misleading.~~ **RESOLVED in #35** — `schedule.json` documented as display-only metadata (read by `status`/`stop`; cron gates cadence, not this file); `--force` help corrected to "Bypass sponsor bonus-run gate". → **P3.3 done**
 
 ---
 
@@ -84,6 +84,6 @@ Beyond that, breadth (more languages), non-Claude backend robustness, and packag
 | P2.6 | [#32](https://github.com/frankbria/code-evolve/issues/32) | Medium | Add a "respect existing repo conventions" pass for mature repos | — |
 | P3.1 | [#33](https://github.com/frankbria/code-evolve/issues/33) | Low | Add jest + first unit tests; fix the broken `npm test` | — |
 | P3.2 | [#34](https://github.com/frankbria/code-evolve/issues/34) | Low | Fix CLAUDE.md / package.json doc & metadata drift | — |
-| P3.3 | [#35](https://github.com/frankbria/code-evolve/issues/35) | Low | Make `schedule.json` real or document it; fix misleading `--force` help | — |
+| P3.3 | [#35](https://github.com/frankbria/code-evolve/issues/35) ✅ | Low | Make `schedule.json` real or document it; fix misleading `--force` help *(done in #35)* | — |
 
 Priority = importance × dependency. Ship **P0** first (the feature is broken without it), then **P1** (the guided-install experience the project is actually about), then breadth (**P2**) and polish (**P3**).

--- a/src/commands/__tests__/run.test.ts
+++ b/src/commands/__tests__/run.test.ts
@@ -1,0 +1,12 @@
+import { runCommand } from '../run';
+
+describe('run --force help', () => {
+  it('describes the sponsor bonus-run gate, not a nonexistent schedule gate', () => {
+    const force = runCommand.options.find((o) => o.long === '--force');
+    expect(force).toBeDefined();
+    // schedule.json never gates runs (it's display-only); the only gate --force
+    // bypasses is the sponsor bonus-run gate in evolve.sh.
+    expect(force!.description.toLowerCase()).toContain('bonus-run');
+    expect(force!.description.toLowerCase()).not.toContain('schedule');
+  });
+});

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,7 +8,7 @@ export const runCommand = new Command('run')
   .description('Run one evolution cycle')
   .option('--model <model>', 'LLM model to use (default depends on agent)')
   .option('--timeout <seconds>', 'Max session time in seconds', '3600')
-  .option('--force', 'Bypass schedule gate')
+  .option('--force', 'Bypass sponsor bonus-run gate')
   .option('--agent <name>', 'Agent backend to use (overrides config)')
   .action(async (options: { model?: string; timeout: string; force?: boolean; agent?: string }) => {
     if (!isInitialized()) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -31,7 +31,9 @@ export interface ScheduleOptions {
 
 /**
  * Install (or replace) the local cron job for this project and persist
- * schedule.json. Writes .evolve/.env capturing the current API key (if any).
+ * schedule.json (display-only metadata read by `status`/`stop` — the cron
+ * expression is the only thing that gates run cadence; schedule.json never
+ * does). Writes .evolve/.env capturing the current API key (if any).
  * Shared by `code-evolve start` and `code-evolve init --mode local|both`.
  * Throws if the crontab update fails. Does NOT validate env keys — callers
  * decide whether a missing key is fatal.
@@ -70,7 +72,7 @@ export function installLocalSchedule(opts: ScheduleOptions): void {
   const updated = existing ? existing + '\n' + cronCommand + '\n' : cronCommand + '\n';
   setCrontab(updated);
 
-  // Save schedule config for status command
+  // Save schedule config for `status` display / `stop` cleanup (not a run gate)
   const scheduleConfig = { every: hours, model, agent, authMode: authMode || 'api-key', started: new Date().toISOString() };
   fs.writeFileSync(path.join(evolveDir, 'schedule.json'), JSON.stringify(scheduleConfig, null, 2) + '\n');
 }


### PR DESCRIPTION
## Summary
`schedule.json` is written by `start` and read only by `status`/`stop` for display/cleanup — `evolve.sh` never consumes it, so it does **not** gate runs. The `--force` help text claimed to "Bypass schedule gate", but the only run gate that exists is the sponsor bonus-run gate in `evolve.sh`.

Chose to **document `schedule.json` as display-only** rather than build a real throttle gate — cron already enforces the configured interval, so a throttle gate would be redundant runtime state in the orchestrator (YAGNI).

## Changes
- `src/commands/run.ts`: `--force` help → "Bypass sponsor bonus-run gate"
- `src/commands/start.ts`: document `schedule.json` as display-only metadata (cron gates cadence, not this file)
- `src/commands/__tests__/run.test.ts`: assert the corrected `--force` wording
- `docs/STATUS.md`: mark P3.3 resolved

## Demo (acceptance evidence)
- `code-evolve run --help` now shows `--force  Bypass sponsor bonus-run gate`
- `grep -c schedule.json templates/scripts/evolve.sh` → `0` (orchestrator never reads it, matching new docs)

## Testing
- `npm run build` ✅  `npm run lint` ✅  `npm test` ✅ (19 tests)
- `codex review --uncommitted`: no issues

## Known Limitations
- Cross-family review by CodeRabbit runs on this PR.

Closes #35

https://claude.ai/code/session_01VpLN9ubKwCeaDRhuwDLF9q